### PR TITLE
Tank tooltip fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /run/
 /build/
 /eclipse/
+.vscode
 .classpath
 .project
 /bin/

--- a/src/main/java/com/darkona/adventurebackpack/client/gui/GuiAdvBackpack.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/gui/GuiAdvBackpack.java
@@ -191,7 +191,9 @@ public class GuiAdvBackpack extends GuiWithTanks
         }
     }
 
-    
+    /**
+     * An instance of this class will handle tooltips for all instances of GuiAdvBackpack
+     */
     public static class TooltipHandler implements IContainerTooltipHandler
     {
 
@@ -203,7 +205,7 @@ public class GuiAdvBackpack extends GuiWithTanks
             GuiWithTanks backpackGui = (GuiWithTanks) gui;
 
             // Fluid tank tooltips
-            if (ConfigHandler.tanksHoveringText && GuiContainerManager.shouldShowTooltip(gui)  && currenttip.size() == 0)
+            if (GuiContainerManager.shouldShowTooltip(gui)  && currenttip.size() == 0)
             {
                 if (tankLeft.inTank(backpackGui, mouseX, mouseY))
                     currenttip.addAll(tankLeft.getTankTooltip());
@@ -234,7 +236,9 @@ public class GuiAdvBackpack extends GuiWithTanks
     }
 
     static {
-        // Creating a single instance of TooltipHandler to handle tooltips for all instances of GuiAdvBackpack
-        GuiContainerManager.addTooltipHandler(new TooltipHandler());
+        // Only instantiate TooltipHandler if enabled in config.
+        if (ConfigHandler.tanksHoveringText) {
+            GuiContainerManager.addTooltipHandler(new TooltipHandler());
+        }
     }
 }

--- a/src/main/java/com/darkona/adventurebackpack/client/gui/GuiAdvBackpack.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/gui/GuiAdvBackpack.java
@@ -3,8 +3,12 @@ package com.darkona.adventurebackpack.client.gui;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
+import codechicken.nei.guihook.GuiContainerManager;
+import codechicken.nei.guihook.IContainerTooltipHandler;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidTank;
@@ -24,6 +28,8 @@ import com.darkona.adventurebackpack.network.SleepingBagPacket;
 import com.darkona.adventurebackpack.reference.LoadedMods;
 import com.darkona.adventurebackpack.util.Resources;
 import com.darkona.adventurebackpack.util.TinkersUtils;
+
+import java.util.List;
 
 /**
  * Created on 12/10/2014
@@ -100,14 +106,6 @@ public class GuiAdvBackpack extends GuiWithTanks
                 equipButton.draw(this, 96, 208);
             else
                 equipButton.draw(this, 77, 208);
-        }
-        if (ConfigHandler.tanksHoveringText)
-        {
-            if (tankLeft.inTank(this, mouseX, mouseY))
-                drawHoveringText(tankLeft.getTankTooltip(), mouseX, mouseY, fontRendererObj);
-
-            if (tankRight.inTank(this, mouseX, mouseY))
-                drawHoveringText(tankRight.getTankTooltip(), mouseX, mouseY, fontRendererObj);
         }
 
         if (LoadedMods.TCONSTRUCT && ConfigHandler.tinkerToolsMaintenance)
@@ -191,5 +189,52 @@ public class GuiAdvBackpack extends GuiWithTanks
                 inventory.getExtendedProperties().removeTag(Constants.TAG_HOLDING_SPACE);
             }
         }
+    }
+
+    
+    public static class TooltipHandler implements IContainerTooltipHandler
+    {
+
+        @Override
+        public List<String> handleTooltip(GuiContainer gui, int mouseX, int mouseY, List<String> currenttip) {
+            if (gui.getClass() != GuiAdvBackpack.class)
+                return currenttip;
+
+            GuiWithTanks backpackGui = (GuiWithTanks) gui;
+
+            // Fluid tank tooltips
+            if (ConfigHandler.tanksHoveringText && GuiContainerManager.shouldShowTooltip(gui)  && currenttip.size() == 0)
+            {
+                if (tankLeft.inTank(backpackGui, mouseX, mouseY))
+                    currenttip.addAll(tankLeft.getTankTooltip());
+    
+                if (tankRight.inTank(backpackGui, mouseX, mouseY))
+                    currenttip.addAll(tankRight.getTankTooltip());
+            }
+
+            return currenttip;
+        }
+
+        /**
+         * Required by IContainerTooltipHandler implementation but not needed here
+         */
+        @Override
+        public List<String> handleItemDisplayName(GuiContainer gui, ItemStack itemstack, List<String> currenttip) {
+            return currenttip;
+        }
+
+        /**
+         * Required by IContainerTooltipHandler implementation but not needed here
+         */
+        @Override
+        public List<String> handleItemTooltip(GuiContainer gui, ItemStack itemstack, int mousex, int mousey,
+                List<String> currenttip) {
+            return currenttip;
+        }
+    }
+
+    static {
+        // Creating a single instance of TooltipHandler to handle tooltips for all instances of GuiAdvBackpack
+        GuiContainerManager.addTooltipHandler(new TooltipHandler());
     }
 }

--- a/src/main/java/com/darkona/adventurebackpack/client/gui/GuiTank.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/gui/GuiTank.java
@@ -16,6 +16,7 @@ import codechicken.lib.render.TextureUtils;
 import com.darkona.adventurebackpack.common.Constants;
 import com.darkona.adventurebackpack.config.ConfigHandler;
 import com.darkona.adventurebackpack.util.LogHelper;
+import com.darkona.adventurebackpack.util.TipUtils;
 
 /**
  * Created by Darkona on 12/10/2014.
@@ -58,8 +59,8 @@ public class GuiTank
     public List<String> getTankTooltip()
     {
         FluidStack fluid = tank.getFluid();
-        String fluidName = (fluid != null) ? fluid.getLocalizedName() : "None";
-        String fluidAmount = (fluid != null) ? fluid.amount + "/" + Constants.BASIC_TANK_CAPACITY : "Empty";
+        String fluidName = (fluid != null) ? fluid.getLocalizedName() : TipUtils.l10n("empty");
+        String fluidAmount = ((fluid != null) ? fluid.amount : 0) + "/" + Constants.BASIC_TANK_CAPACITY;
         ArrayList<String> tankTips = new ArrayList<String>();
         tankTips.add(fluidName);
         tankTips.add(fluidAmount);

--- a/src/main/java/com/darkona/adventurebackpack/config/ConfigHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/config/ConfigHandler.java
@@ -31,7 +31,7 @@ public class ConfigHandler
     public static boolean enableTemperatureBar = false;
     public static boolean enableToolsRender = true;
     public static int typeTankRender = 2;
-    public static boolean tanksHoveringText = false;
+    public static boolean tanksHoveringText = true;
 
     public static boolean statusOverlay = true;
     public static boolean statusOverlayLeft = true;
@@ -118,7 +118,7 @@ public class ConfigHandler
         enableFullnessBar = config.getBoolean("Enable Fullness Bar", "graphics", false, "Enable durability bar showing fullness of backpacks inventory");
         enableTemperatureBar = config.getBoolean("Enable Temperature Bar", "graphics", false, "Enable durability bar showing temperature of jetpack");
         enableToolsRender = config.getBoolean("Enable Tools Render", "graphics", true, "Enable rendering for tools in the backpack tool slots");
-        tanksHoveringText = config.getBoolean("Hovering Text", "graphics", false, "Show hovering text on fluid tanks?");
+        tanksHoveringText = config.getBoolean("Hovering Text", "graphics", true, "Show hovering text on fluid tanks?");
 
         // Graphics.Status
         statusOverlay = config.getBoolean("Enable Overlay", "graphics.status", true, "Show player status effects on screen?");


### PR DESCRIPTION
- Fix tank tooltips rendering rendering under items
- Changed tooltip to always display the tank's capacity
- Enabled tank tooltips by default since they're no longer broken

This change mostly  involves using GuiContainerManager to handle the tooltip rendering. Enabling `"Hovering Text"` in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/blob/master/config/adventurebackpack.cfg will be necessary for the feature to be enabled in the pack.

The rationale for changing the default config is that I assume that it defaulted to being disabled due to the feature not working very well.

### Before
<img src="https://user-images.githubusercontent.com/5321549/147312226-8c473e8f-6b5b-4ae8-8cbf-d87378fb14ce.png" width="75%" height="75%" />

### After
![backpack-tooltip-fixed](https://user-images.githubusercontent.com/5321549/147312227-afbfd214-aa8b-41a6-8ba2-c8147b51b5db.png)