### PR TITLE
Don't spill OpenGL's states out of the mod

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/client/gui/GuiAdvBackpack.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/gui/GuiAdvBackpack.java
@@ -124,10 +124,12 @@ public class GuiAdvBackpack extends GuiWithTanks
         inventory.openInventory();
         FluidTank lft = inventory.getLeftTank();
         FluidTank rgt = inventory.getRightTank();
+        GL11.glPushAttrib(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LIGHTING_BIT);
+
         tankLeft.draw(this, lft);
         tankRight.draw(this, rgt);
-        GL11.glDisable(GL11.GL_LIGHTING);
-        GL11.glDisable(GL11.GL_BLEND);
+
+        GL11.glPopAttrib();
     }
 
     @Override

--- a/src/main/java/com/darkona/adventurebackpack/client/gui/GuiCoalJetpack.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/gui/GuiCoalJetpack.java
@@ -81,6 +81,8 @@ public class GuiCoalJetpack extends GuiWithTanks
         inventory.openInventory();
         FluidTank water = inventory.getWaterTank();
         FluidTank steam = inventory.getSteamTank();
+        GL11.glPushAttrib(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LIGHTING_BIT);
+
         GL11.glPushMatrix();
         GL11.glEnable(GL11.GL_BLEND);
         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
@@ -137,6 +139,8 @@ public class GuiCoalJetpack extends GuiWithTanks
         fontRendererObj.drawString((inventory.getTemperature()) + " C", 0, 0, 0x373737, false);
         GL11.glScalef(1, 1, 1);
         GL11.glPopMatrix();
+
+        GL11.glPopAttrib();
     }
 
     @Override

--- a/src/main/java/com/darkona/adventurebackpack/client/gui/GuiCopterPack.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/gui/GuiCopterPack.java
@@ -73,6 +73,8 @@ public class GuiCopterPack extends GuiWithTanks
     @Override
     protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY)
     {
+        GL11.glPushAttrib(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LIGHTING_BIT);
+
         GL11.glDisable(GL11.GL_LIGHTING);
         GL11.glDisable(GL11.GL_BLEND);
         inventory.openInventory();
@@ -96,7 +98,9 @@ public class GuiCopterPack extends GuiWithTanks
             String conLev = (rate != null) ? rate.toString() : "0";
             fontRendererObj.drawString("Consumption: " + conLev, 1 + offsetX, 40 + offsetY, 0x373737, false);
         }
+
         GL11.glPopMatrix();
+        GL11.glPopAttrib();
     }
 
     @Override

--- a/src/main/java/com/darkona/adventurebackpack/client/gui/GuiOverlay.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/gui/GuiOverlay.java
@@ -86,6 +86,7 @@ public class GuiOverlay extends Gui
         ScaledResolution resolution = new ScaledResolution(this.mc, this.mc.displayWidth, this.mc.displayHeight);
         screenWidth = resolution.getScaledWidth();
         screenHeight = resolution.getScaledHeight();
+        GL11.glPushAttrib(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LIGHTING_BIT | GL11.GL_TRANSFORM_BIT);
 
         if (ConfigHandler.bossBarIndent != 0)
         {
@@ -214,10 +215,9 @@ public class GuiOverlay extends Gui
                     GL11.glPopMatrix();
                     RenderHelper.disableStandardItemLighting();
                 }
-                GL11.glDisable(GL12.GL_RESCALE_NORMAL);
-                GL11.glDisable(GL11.GL_BLEND);
             }
         }
+        GL11.glPopAttrib();
     }
 
     private void drawTank(FluidTank tank, int startX, int startY, int height, int width)

--- a/src/main/java/com/darkona/adventurebackpack/client/models/ModelBackpackBlock.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/models/ModelBackpackBlock.java
@@ -367,6 +367,7 @@ public class ModelBackpackBlock extends ModelBase
     private void renderBackpack(IInventoryBackpack backpack, float scale)
     {
         BackpackTypes type = backpack.getType();
+        GL11.glPushAttrib(GL11.GL_COLOR_BUFFER_BIT);
 
         if (type == QUARTZ || type == SLIME || type == SNOW)
         {
@@ -412,6 +413,7 @@ public class ModelBackpackBlock extends ModelBase
             GL11.glDisable(GL11.GL_CULL_FACE);
             GL11.glDisable(GL11.GL_BLEND);
         }*/
+        GL11.glPopAttrib();
     }
 
     /**

--- a/src/main/java/com/darkona/adventurebackpack/client/render/CopygirlRenderUtils.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/render/CopygirlRenderUtils.java
@@ -58,7 +58,7 @@ public final class CopygirlRenderUtils
             return;
         }
         Item item = stack.getItem();
-
+        GL11.glPushAttrib(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LIGHTING_BIT | GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_TRANSFORM_BIT);
         GL11.glPushMatrix();
 
         Tessellator tessellator = Tessellator.instance;
@@ -108,14 +108,10 @@ public final class CopygirlRenderUtils
             ItemRenderer.renderItemIn2D(tessellator, 0.0F, 0.0F, 1.0F, 1.0F, 256, 256, 0.0625F);
             GL11.glPopMatrix();
             GL11.glMatrixMode(GL11.GL_MODELVIEW);
-            GL11.glDisable(GL11.GL_BLEND);
-            GL11.glEnable(GL11.GL_LIGHTING);
-            GL11.glDepthFunc(GL11.GL_LEQUAL);
         }
 
-        GL11.glDisable(GL12.GL_RESCALE_NORMAL);
-
         GL11.glPopMatrix();
+        GL11.glPopAttrib();
     }
 
     public static void setColorFromInt(int color)

--- a/src/main/java/com/darkona/adventurebackpack/client/render/RendererAdventureBackpackBlock.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/render/RendererAdventureBackpackBlock.java
@@ -30,6 +30,9 @@ public class RendererAdventureBackpackBlock extends TileEntitySpecialRenderer
     public void renderTileEntityAt(TileEntity te, double x, double y, double z, float par8)
     {
         TileAdventureBackpack tileBackpack = (TileAdventureBackpack) te;
+        GL11.glPushAttrib(GL11.GL_TRANSFORM_BIT);
+        GL11.glPushMatrix();
+
         int dir = te.getBlockMetadata();
         if ((dir & 8) >= 8)
         {
@@ -40,14 +43,9 @@ public class RendererAdventureBackpackBlock extends TileEntitySpecialRenderer
             dir -= 4;
         }
 
-        GL11.glPushMatrix();
         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glTranslatef((float) x + 0.5F, (float) y + 0.5f, (float) z + 0.5F);
-
-        GL11.glPushMatrix();
         GL11.glRotatef(180F, 0.0F, 0.0F, 1.0F);
-
-        GL11.glPushMatrix();
         if (dir == 0)
         {
             GL11.glRotatef(-180F, 0.0F, 1.0F, 0.0F);
@@ -65,9 +63,7 @@ public class RendererAdventureBackpackBlock extends TileEntitySpecialRenderer
         bindTexture(modelTexture);
         model.render(null, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1 / 20F, tileBackpack);
 
-        GL11.glDisable(GL12.GL_RESCALE_NORMAL);
         GL11.glPopMatrix();
-        GL11.glPopMatrix();
-        GL11.glPopMatrix();
+        GL11.glPopAttrib();
     }
 }

--- a/src/main/java/com/darkona/adventurebackpack/client/render/RendererCampFire.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/render/RendererCampFire.java
@@ -28,17 +28,21 @@ public class RendererCampFire extends TileEntitySpecialRenderer
     public void renderTileEntityAt(TileEntity te, double x, double y, double z, float par8)
     {
         ResourceLocation modelTexture = Resources.modelTextures("campFire");
+        GL11.glPushAttrib(GL11.GL_TRANSFORM_BIT);
         GL11.glPushMatrix();
+
         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
         GL11.glTranslatef((float) x + 0.5F, (float) y + 1.2f, (float) z + 0.5F);
-        GL11.glPushMatrix();
+//        GL11.glPushMatrix();
         GL11.glRotatef(180F, 0.0F, 0.0F, 1.0F);
 
         bindTexture(modelTexture);
         model.render(null, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1 / 20F);
 
         GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+//        GL11.glPopMatrix();
+
         GL11.glPopMatrix();
-        GL11.glPopMatrix();
+        GL11.glPopAttrib();
     }
 }

--- a/src/main/java/com/darkona/adventurebackpack/client/render/RendererWearableEquipped.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/render/RendererWearableEquipped.java
@@ -41,40 +41,32 @@ public class RendererWearableEquipped extends RendererLivingEntity
 
     public void render(Entity entity, double x, double y, double z, float rotX, float rotY, float rotZ, float yaw, float pitch)
     {
+        if (!Wearing.isWearingWearable((EntityPlayer) entity)) return;
+        GL11.glPushAttrib(GL11.GL_TRANSFORM_BIT);
+
+        ItemStack wearable = Wearing.getWearingWearable((EntityPlayer) entity).copy();
+        IBackWearableItem wearableItem = (IBackWearableItem) wearable.getItem();
+        modelBipedMain = wearableItem.getWearableModel(wearable);
+        texture = wearableItem.getWearableTexture(wearable);
+        modelBipedMain.bipedBody.rotateAngleX = rotX;
+        modelBipedMain.bipedBody.rotateAngleY = rotY;
+        modelBipedMain.bipedBody.rotateAngleZ = rotZ;
         try
         {
-            if (!Wearing.isWearingWearable((EntityPlayer) entity)) return;
-            ItemStack wearable = Wearing.getWearingWearable((EntityPlayer) entity).copy();
-            IBackWearableItem wearableItem = (IBackWearableItem) wearable.getItem();
-            modelBipedMain = wearableItem.getWearableModel(wearable);
-            texture = wearableItem.getWearableTexture(wearable);
-            modelBipedMain.bipedBody.rotateAngleX = rotX;
-            modelBipedMain.bipedBody.rotateAngleY = rotY;
-            modelBipedMain.bipedBody.rotateAngleZ = rotZ;
-            GL11.glColor3f(1.0F, 1.0F, 1.0F);
-            GL11.glPushMatrix();
-            try
-            {
-                GL11.glEnable(GL12.GL_RESCALE_NORMAL);
-                renderMainModel((EntityPlayer) entity, 0, 0, 0, 0, 0, 0.0625f);
-            }
-            catch (Exception oops)
-            {
-
-            }
-            OpenGlHelper.setActiveTexture(OpenGlHelper.lightmapTexUnit);
-            GL11.glEnable(GL11.GL_TEXTURE_2D);
-            OpenGlHelper.setActiveTexture(OpenGlHelper.defaultTexUnit);
-            GL11.glPopMatrix();
+            GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+            renderMainModel((EntityPlayer) entity, 0, 0, 0, 0, 0, 0.0625f);
         }
         catch (Exception ex)
         {
-            //discard silently because NO ONE CARES
         }
+
+        GL11.glPopAttrib();
     }
 
     protected void renderMainModel(EntityLivingBase entity, float limbSwing1, float limbswing2, float z, float yaw, float whatever, float scale)
     {
+        GL11.glPushAttrib(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_TEXTURE_BIT);
+
         bindTexture(this.texture);
         if (!entity.isInvisible())
         {
@@ -89,14 +81,13 @@ public class RendererWearableEquipped extends RendererLivingEntity
             GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
             GL11.glAlphaFunc(GL11.GL_GREATER, 0.003921569F);
             modelBipedMain.render(entity, limbSwing1, limbswing2, z, yaw, whatever, scale);
-            GL11.glDisable(GL11.GL_BLEND);
-            GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);
             GL11.glPopMatrix();
-            GL11.glDepthMask(true);
         }
         else
         {
             modelBipedMain.setRotationAngles(limbSwing1, limbswing2, z, yaw, whatever, scale, entity);
         }
+
+        GL11.glPopAttrib();
     }
 }


### PR DESCRIPTION
Adding glPushAttrib() / glPopAttrib() pairs around glEnable()/glDisable() calls
Fix GTNewHorizons/GT-New-Horizons-Modpack/issues/8349