### PR TITLE
unbind unuse keybind by default

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/config/Keybindings.java
+++ b/src/main/java/com/darkona/adventurebackpack/config/Keybindings.java
@@ -16,8 +16,8 @@ public class Keybindings {
     private static final String OPEN_INVENTORY = "keys.adventureBackpack.openInventory";
     private static final String TOGGLE_ACTIONS = "keys.adventureBackpack.toggleActions";
 
-    public static KeyBinding openInventory = new KeyBinding(OPEN_INVENTORY, Keyboard.KEY_B, KEYS_CATEGORY);
-    public static KeyBinding toggleActions = new KeyBinding(TOGGLE_ACTIONS, Keyboard.KEY_N, KEYS_CATEGORY);
+    public static KeyBinding openInventory = new KeyBinding(OPEN_INVENTORY, Keyboard.KEY_NONE, KEYS_CATEGORY);
+    public static KeyBinding toggleActions = new KeyBinding(TOGGLE_ACTIONS, Keyboard.KEY_NONE, KEYS_CATEGORY);
 
     public static String getInventoryKeyName() {
         return GameSettings.getKeyDisplayString(openInventory.getKeyCode());


### PR DESCRIPTION
The goal is to unbind all keys that are not used from the start of the game in the GTNH modpack to avoid all the current keybinds conflict and leave to the user the choice of the keybinds they want.

This one actually conflicts with the other backpack mod