### PR TITLE
Fix unequipping Piston Boots with armor stand not resets step height #12780

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
@@ -113,17 +113,12 @@ public class PlayerEventHandler {
 
     @SubscribeEvent
     public void pistonBootsUnequipped(LivingEvent.LivingUpdateEvent event) {
-        if (event.entityLiving instanceof EntityPlayer) {
+        if (event.entityLiving instanceof EntityPlayer && ConfigHandler.pistonBootsAutoStep) {
             EntityPlayer player = (EntityPlayer) event.entityLiving;
             if (Wearing.isWearingBoots(player)) {
-                if (!pistonBootsStepHeight) {
-                    pistonBootsStepHeight = true;
-                }
+                player.stepHeight = 1.001F;
             } else {
-                if (pistonBootsStepHeight) {
-                    player.stepHeight = 0.5001F;
-                    pistonBootsStepHeight = false;
-                }
+                player.stepHeight = 0.5001F;
             }
         }
     }

--- a/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
@@ -109,8 +109,6 @@ public class PlayerEventHandler {
         }
     }
 
-    private boolean pistonBootsStepHeight = false;
-
     @SubscribeEvent
     public void pistonBootsUnequipped(LivingEvent.LivingUpdateEvent event) {
         if (event.entityLiving instanceof EntityPlayer && ConfigHandler.pistonBootsAutoStep) {

--- a/src/main/java/com/darkona/adventurebackpack/item/ItemPistonBoots.java
+++ b/src/main/java/com/darkona/adventurebackpack/item/ItemPistonBoots.java
@@ -22,7 +22,6 @@ public class ItemPistonBoots extends ArmorAB {
 
     @Override
     public void onArmorTick(World world, EntityPlayer player, ItemStack itemStack) {
-        if (ConfigHandler.pistonBootsAutoStep) player.stepHeight = 1.001F;
         if (ConfigHandler.pistonBootsSprintBoost != 0 && player.isSprinting()) player.addPotionEffect(
                 new PotionEffect(Potion.moveSpeed.getId(), 1, ConfigHandler.pistonBootsSprintBoost - 1));
     }


### PR DESCRIPTION
GTNewHorizons/GT-New-Horizons-Modpack#12780
Fix, made step height logic only in Update Event.