### PR TITLE
Fix hight step break boots from other mods

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
@@ -1,5 +1,8 @@
 package com.darkona.adventurebackpack.handlers;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.item.EntityItem;
@@ -20,9 +23,6 @@ import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.player.EntityInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerDropsEvent;
 import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import com.darkona.adventurebackpack.block.BlockSleepingBag;
 import com.darkona.adventurebackpack.common.ServerActions;

--- a/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
@@ -21,6 +21,9 @@ import net.minecraftforge.event.entity.player.EntityInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerDropsEvent;
 import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.darkona.adventurebackpack.block.BlockSleepingBag;
 import com.darkona.adventurebackpack.common.ServerActions;
 import com.darkona.adventurebackpack.config.ConfigHandler;
@@ -50,6 +53,8 @@ import cpw.mods.fml.common.gameevent.TickEvent;
  * @see com.darkona.adventurebackpack.client.ClientActions
  */
 public class PlayerEventHandler {
+
+    public static List<String> stepBoostedPlayers = new ArrayList<>();
 
     @SubscribeEvent
     public void registerBackpackProperty(EntityEvent.EntityConstructing event) {
@@ -105,25 +110,6 @@ public class PlayerEventHandler {
 
             if (Wearing.isWearingBoots(player) && player.onGround) {
                 ServerActions.pistonBootsJump(player);
-            }
-        }
-    }
-
-    private boolean pistonBootsStepHeight = false;
-
-    @SubscribeEvent
-    public void pistonBootsUnequipped(LivingEvent.LivingUpdateEvent event) {
-        boolean isAutoStepEnabled = ConfigHandler.pistonBootsAutoStep;
-        if (event.entityLiving instanceof EntityPlayer && (isAutoStepEnabled || pistonBootsStepHeight)) {
-            EntityPlayer player = (EntityPlayer) event.entityLiving;
-            if (Wearing.isWearingBoots(player)) {
-                if (isAutoStepEnabled) {
-                    player.stepHeight = 1.0001F;
-                    pistonBootsStepHeight = true;
-                }
-            } else if (pistonBootsStepHeight) {
-                player.stepHeight = 0.5001F;
-                pistonBootsStepHeight = false;
             }
         }
     }
@@ -323,6 +309,19 @@ public class PlayerEventHandler {
                         BackpackProperty.get(player).setWakingUpInPortableBag(false);
                     }
                 }
+            }
+        }
+        if (player != null && !player.isDead && player instanceof EntityPlayer) {
+            String playerName = player.getGameProfile().getName();
+            boolean stepBoosted = stepBoostedPlayers.contains(playerName);
+            if (Wearing.isWearingBoots(player)) {
+                player.stepHeight = 1.001F;
+                if (ConfigHandler.pistonBootsAutoStep && !stepBoosted) {
+                    stepBoostedPlayers.add(playerName);
+                }
+            } else if (stepBoosted) {
+                player.stepHeight = 0.501F;
+                stepBoostedPlayers.remove(playerName);
             }
         }
     }

--- a/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
@@ -122,8 +122,8 @@ public class PlayerEventHandler {
                     pistonBootsStepHeight = true;
                 }
             } else if (pistonBootsStepHeight) {
-                pistonBootsStepHeight = false;
                 player.stepHeight = 0.5001F;
+                pistonBootsStepHeight = false;
             }
         }
     }

--- a/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
@@ -109,13 +109,20 @@ public class PlayerEventHandler {
         }
     }
 
+    private boolean pistonBootsStepHeight = false;
+
     @SubscribeEvent
     public void pistonBootsUnequipped(LivingEvent.LivingUpdateEvent event) {
-        if (event.entityLiving instanceof EntityPlayer && ConfigHandler.pistonBootsAutoStep) {
+        boolean isAutoStepEnabled = ConfigHandler.pistonBootsAutoStep;
+        if (event.entityLiving instanceof EntityPlayer && (isAutoStepEnabled || pistonBootsStepHeight)) {
             EntityPlayer player = (EntityPlayer) event.entityLiving;
             if (Wearing.isWearingBoots(player)) {
-                player.stepHeight = 1.001F;
-            } else {
+                if (isAutoStepEnabled) {
+                    player.stepHeight = 1.0001F;
+                    pistonBootsStepHeight = true;
+                }
+            } else if (pistonBootsStepHeight) {
+                pistonBootsStepHeight = false;
                 player.stepHeight = 0.5001F;
             }
         }

--- a/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
@@ -1,7 +1,6 @@
 package com.darkona.adventurebackpack.handlers;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.SharedMonsterAttributes;
@@ -54,7 +53,7 @@ import cpw.mods.fml.common.gameevent.TickEvent;
  */
 public class PlayerEventHandler {
 
-    public static List<String> stepBoostedPlayers = new ArrayList<>();
+    public static HashSet<String> stepBoostedPlayers = new HashSet<String>();
 
     @SubscribeEvent
     public void registerBackpackProperty(EntityEvent.EntityConstructing event) {


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12859

https://github.com/GTNewHorizons/AdventureBackpack2/pull/12/ accidently broke the high-step ability for other mods.

This PR mostly reverts the code by the PR linked above but keeps the fix that introduces it. On the top it now only reset the `stepHeight` when it has been adjusted and the piston boots are not equiped anymore.

Feel free to correct me here, if you have a better solution. :)

I've tested around with both, travler boots (Tinkers Construct) and piston boots. I switched between them both several times and I loose the high-step ability whenever I unequip them.