### PR TITLE
Handle mouse keybinds without keyboard input

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,8 +1,8 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:waila:1.6.5:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.5.4-GTNH:dev")
+    api("com.github.GTNewHorizons:waila:1.7.1:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.5.24-GTNH:dev")
     
-    devOnlyNonPublishable("com.github.GTNewHorizons:TinkersConstruct:1.11.5-GTNH:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:TinkersConstruct:1.11.12-GTNH:dev")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -50,10 +50,10 @@ enableGenericInjection = false
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.
 # If gradleTokenVersion is empty or missing, the field will not be present in the class.
-generateGradleTokenClass =
+generateGradleTokenClass = com.darkona.adventurebackpack.reference.Tags
 
 # Name of the token containing the project's current version to generate/replace.
-gradleTokenVersion = GRADLETOKEN_VERSION
+gradleTokenVersion = VERSION
 
 # [DEPRECATED] Mod ID replacement token.
 gradleTokenModId =
@@ -61,13 +61,16 @@ gradleTokenModId =
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
 
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
+
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
 # public static final String VERSION = "GRADLETOKEN_VERSION";
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...]).
 # Leave these properties empty to skip individual token replacements.
-replaceGradleTokenInFile = ModInfo.java
+replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ curseForgeRelations =
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.19'
 }
 
 

--- a/src/main/java/com/darkona/adventurebackpack/handlers/KeyInputEventHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/handlers/KeyInputEventHandler.java
@@ -29,6 +29,15 @@ public class KeyInputEventHandler {
 
     @SubscribeEvent
     public void handleKeyInputEvent(InputEvent.KeyInputEvent event) {
+        this.onInput();
+    }
+
+    @SubscribeEvent
+    public void handleMouseInputEvent(InputEvent.MouseInputEvent event) {
+        this.onInput();
+    }
+
+    public void onInput() {
         Key pressedKey = getPressedKeyBinding();
         Minecraft mc = Minecraft.getMinecraft();
         EntityPlayer player = mc.thePlayer;

--- a/src/main/java/com/darkona/adventurebackpack/reference/ModInfo.java
+++ b/src/main/java/com/darkona/adventurebackpack/reference/ModInfo.java
@@ -4,7 +4,7 @@ public class ModInfo {
 
     public static final String MOD_ID = "adventurebackpack"; // must be lowercase
     public static final String MOD_NAME = "Adventure Backpack";
-    public static final String MOD_VERSION = "GRADLETOKEN_VERSION";
+    public static final String MOD_VERSION = Tags.VERSION;
     public static final String GUI_FACTORY_CLASS = "com.darkona.adventurebackpack.client.gui.GuiFactory";
     public static final String MOD_CLIENT_PROXY = "com.darkona.adventurebackpack.proxy.ClientProxy";
     public static final String MOD_SERVER_PROXY = "com.darkona.adventurebackpack.proxy.ServerProxy";


### PR DESCRIPTION
Mouse keybinds aren't recognized by `InputEvent.KeyInputEvent` until a key on the actual keyboard is pressed. 
They are recognized without keyboard input by `InputEvent.MouseInputEvent`. 

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15679