### PR TITLE
Add config option to hide backpack model from rendering on back and also now works with the Translucency II enchantment

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/client/render/RendererWearableEquipped.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/render/RendererWearableEquipped.java
@@ -13,6 +13,7 @@ import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
+import com.darkona.adventurebackpack.config.ConfigHandler;
 import com.darkona.adventurebackpack.item.IBackWearableItem;
 import com.darkona.adventurebackpack.util.Wearing;
 
@@ -35,6 +36,9 @@ public class RendererWearableEquipped extends RendererLivingEntity {
             float pitch) {
         final ItemStack wearable = Wearing.getWearingWearable((EntityPlayer) entity);
         if (wearable == null) {
+            return;
+        }
+        if (!ConfigHandler.enableBackRendering) {
             return;
         }
         GL11.glPushAttrib(GL11.GL_TRANSFORM_BIT);

--- a/src/main/java/com/darkona/adventurebackpack/client/render/RendererWearableEquipped.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/render/RendererWearableEquipped.java
@@ -15,6 +15,7 @@ import org.lwjgl.opengl.GL12;
 
 import com.darkona.adventurebackpack.config.ConfigHandler;
 import com.darkona.adventurebackpack.item.IBackWearableItem;
+import com.darkona.adventurebackpack.util.EnchUtils;
 import com.darkona.adventurebackpack.util.Wearing;
 
 public class RendererWearableEquipped extends RendererLivingEntity {
@@ -39,6 +40,9 @@ public class RendererWearableEquipped extends RendererLivingEntity {
             return;
         }
         if (!ConfigHandler.enableBackRendering) {
+            return;
+        }
+        if (EnchUtils.isTranslucent(wearable)) {
             return;
         }
         GL11.glPushAttrib(GL11.GL_TRANSFORM_BIT);

--- a/src/main/java/com/darkona/adventurebackpack/client/render/RendererWearableEquipped.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/render/RendererWearableEquipped.java
@@ -42,7 +42,7 @@ public class RendererWearableEquipped extends RendererLivingEntity {
         if (!ConfigHandler.enableBackRendering) {
             return;
         }
-        if (EnchUtils.isTranslucent(wearable)) {
+        if (EnchUtils.getTranslucencyLevel(wearable) == 2) {
             return;
         }
         GL11.glPushAttrib(GL11.GL_TRANSFORM_BIT);

--- a/src/main/java/com/darkona/adventurebackpack/config/ConfigHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/config/ConfigHandler.java
@@ -14,6 +14,7 @@ public class ConfigHandler {
     public static Configuration config;
 
     public static boolean allowSoulBound = true;
+    public static boolean allowTranslucency = true;
     public static boolean backpackDeathPlace = true;
     public static boolean backpackAbilities = true;
     public static boolean enableCampfireSpawn = false;
@@ -100,6 +101,8 @@ public class ConfigHandler {
         // Gameplay
         allowSoulBound = config
                 .getBoolean("Allow SoulBound", "gameplay", true, "Allow SoulBound enchant on wearable packs");
+        allowTranslucency = config
+                .getBoolean("Allow Translucency", "gameplay", true, "Allow Translucency enchant on wearable packs");
         backpackAbilities = config.getBoolean(
                 "Backpack Abilities",
                 "gameplay",

--- a/src/main/java/com/darkona/adventurebackpack/config/ConfigHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/config/ConfigHandler.java
@@ -23,6 +23,7 @@ public class ConfigHandler {
     public static boolean portableSleepingBag = true;
     public static boolean tinkerToolsMaintenance = true;
 
+    public static boolean enableBackRendering = true;
     public static boolean enableFullnessBar = false;
     public static boolean enableTemperatureBar = false;
     public static boolean enableToolsRender = true;
@@ -128,6 +129,11 @@ public class ConfigHandler {
                 "Allows to maintenance (repair/upgarde) Tinkers Construct tools in backpacks as if it's Crafting Station");
 
         // Graphics
+        enableBackRendering = config.getBoolean(
+                "Show Backpack on Back",
+                "graphics",
+                true,
+                "Whether or not to render the backpack when wearing it.");
         typeTankRender = config.getInt(
                 "Tank Render Type",
                 "graphics",

--- a/src/main/java/com/darkona/adventurebackpack/item/ItemAdventure.java
+++ b/src/main/java/com/darkona/adventurebackpack/item/ItemAdventure.java
@@ -14,12 +14,12 @@ public abstract class ItemAdventure extends ItemAB implements IBackWearableItem 
         super();
         setFull3D();
         setMaxStackSize(1);
+        setMaxDamage(1000);
     }
 
-    @Override
-    public boolean isDamageable() {
-        return false;
-    }
+    /*
+     * @Override public boolean isDamageable() { return false; }
+     */
 
     @Override
     public int getItemEnchantability() {
@@ -36,6 +36,7 @@ public abstract class ItemAdventure extends ItemAB implements IBackWearableItem 
 
     @Override
     public boolean isBookEnchantable(ItemStack stack, ItemStack book) {
-        return EnchUtils.isSoulBook(book);
+        return EnchUtils.isSoulBook(book) || EnchUtils.isTranslucencyBook(book);
+
     }
 }

--- a/src/main/java/com/darkona/adventurebackpack/item/ItemAdventure.java
+++ b/src/main/java/com/darkona/adventurebackpack/item/ItemAdventure.java
@@ -14,12 +14,17 @@ public abstract class ItemAdventure extends ItemAB implements IBackWearableItem 
         super();
         setFull3D();
         setMaxStackSize(1);
-        setMaxDamage(1000);
     }
 
-    /*
-     * @Override public boolean isDamageable() { return false; }
-     */
+    @Override
+    public boolean isDamageable() {
+        return false;
+    }
+
+    @Override
+    public boolean isItemTool(ItemStack stack) {
+        return true;
+    }
 
     @Override
     public int getItemEnchantability() {

--- a/src/main/java/com/darkona/adventurebackpack/reference/LoadedMods.java
+++ b/src/main/java/com/darkona/adventurebackpack/reference/LoadedMods.java
@@ -19,6 +19,7 @@ public final class LoadedMods {
     public static final boolean THAUMCRAFT = registerMod("Thaumcraft");
     public static final boolean WAILA = registerMod("waila");
     public static final boolean HUNGEROVERHAUL = registerMod("HungerOverhaul");
+    public static final boolean WITCHINGGADGETS = registerMod("WitchingGadgets");
 
     private LoadedMods() {}
 

--- a/src/main/java/com/darkona/adventurebackpack/util/EnchUtils.java
+++ b/src/main/java/com/darkona/adventurebackpack/util/EnchUtils.java
@@ -1,6 +1,7 @@
 package com.darkona.adventurebackpack.util;
 
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -43,54 +44,30 @@ public final class EnchUtils {
     }
 
     public static boolean isSoulBounded(ItemStack stack) {
-        NBTTagList stackEnch = stack.getEnchantmentTagList();
-        if (SOUL_BOUND_ID >= 0 && stackEnch != null) {
-            for (int i = 0; i < stackEnch.tagCount(); i++) {
-                int id = stackEnch.getCompoundTagAt(i).getInteger("id");
-                if (id == SOUL_BOUND_ID) return true;
-            }
-        }
-        return false;
+        if (SOUL_BOUND_ID > 0)
+            return EnchantmentHelper.getEnchantmentLevel(SOUL_BOUND_ID, stack) > 0;
+        else
+            return false;
+
     }
 
-    public static boolean isTranslucent(ItemStack stack) {
-        NBTTagList stackEnch = stack.getEnchantmentTagList();
-        if (TRANSLUCENCY_ID >= 0 && stackEnch != null) {
-            for (int i = 0; i < stackEnch.tagCount(); i++) {
-                int id = stackEnch.getCompoundTagAt(i).getInteger("id");
-                int lvl = stackEnch.getCompoundTagAt(i).getInteger("lvl");
-                if (id == TRANSLUCENCY_ID && lvl == 2) return true;
-            }
-        }
-        return false;
+    public static int getTranslucencyLevel(ItemStack stack) {
+        if (TRANSLUCENCY_ID > 0)
+            return EnchantmentHelper.getEnchantmentLevel(TRANSLUCENCY_ID, stack);
+        else
+            return 0;
     }
 
     public static boolean isSoulBook(ItemStack book) {
-        if (SOUL_BOUND_ID >= 0 && book.hasTagCompound()) {
-            NBTTagCompound bookData = book.stackTagCompound;
-            if (bookData.hasKey("StoredEnchantments")) {
-                NBTTagList bookEnch = bookData.getTagList("StoredEnchantments", NBT.TAG_COMPOUND);
-                if (!bookEnch.getCompoundTagAt(1).getBoolean("id")) // only pure soulbook allowed
-                {
-                    int id = bookEnch.getCompoundTagAt(0).getInteger("id");
-                    return id == SOUL_BOUND_ID;
-                }
-            }
+        if (EnchantmentHelper.getEnchantments(book).size() == 1){ // only pure soulbook allowed
+            return EnchantmentHelper.getEnchantments(book).get(SOUL_BOUND_ID) != null;
         }
         return false;
     }
 
     public static boolean isTranslucencyBook(ItemStack book) {
-        if (TRANSLUCENCY_ID >= 0 && book.hasTagCompound()) {
-            NBTTagCompound bookData = book.stackTagCompound;
-            if (bookData.hasKey("StoredEnchantments")) {
-                NBTTagList bookEnch = bookData.getTagList("StoredEnchantments", NBT.TAG_COMPOUND);
-                if (!bookEnch.getCompoundTagAt(1).getBoolean("id")) // only pure book allowed
-                {
-                    int id = bookEnch.getCompoundTagAt(0).getInteger("id");
-                    return id == TRANSLUCENCY_ID;
-                }
-            }
+        if (EnchantmentHelper.getEnchantments(book).size() == 1){
+            return EnchantmentHelper.getEnchantments(book).get(TRANSLUCENCY_ID) != null;
         }
         return false;
     }

--- a/src/main/java/com/darkona/adventurebackpack/util/EnchUtils.java
+++ b/src/main/java/com/darkona/adventurebackpack/util/EnchUtils.java
@@ -16,6 +16,8 @@ public final class EnchUtils {
     // -1 - enchantment not found
     private static final int SOUL_BOUND_ID = setSoulBoundID();
 
+    private static final int TRANSLUCENCY_ID = setTranslucencyID();
+
     private EnchUtils() {}
 
     private static int setSoulBoundID() {
@@ -25,6 +27,17 @@ public final class EnchUtils {
 
         for (Enchantment ench : Enchantment.enchantmentsList)
             if (ench != null && ench.getName().equals("enchantment.enderio.soulBound")) return ench.effectId;
+
+        return -1;
+    }
+
+    private static int setTranslucencyID() {
+        if (!ConfigHandler.allowTranslucency) return -3;
+
+        if (!LoadedMods.WITCHINGGADGETS) return -2;
+
+        for (Enchantment ench : Enchantment.enchantmentsList)
+            if (ench != null && ench.getName().equals("enchantment.wg.invisibleGear")) return ench.effectId;
 
         return -1;
     }
@@ -40,6 +53,18 @@ public final class EnchUtils {
         return false;
     }
 
+    public static boolean isTranslucent(ItemStack stack) {
+        NBTTagList stackEnch = stack.getEnchantmentTagList();
+        if (TRANSLUCENCY_ID >= 0 && stackEnch != null) {
+            for (int i = 0; i < stackEnch.tagCount(); i++) {
+                int id = stackEnch.getCompoundTagAt(i).getInteger("id");
+                int lvl = stackEnch.getCompoundTagAt(i).getInteger("lvl");
+                if (id == TRANSLUCENCY_ID && lvl == 2) return true;
+            }
+        }
+        return false;
+    }
+
     public static boolean isSoulBook(ItemStack book) {
         if (SOUL_BOUND_ID >= 0 && book.hasTagCompound()) {
             NBTTagCompound bookData = book.stackTagCompound;
@@ -49,6 +74,21 @@ public final class EnchUtils {
                 {
                     int id = bookEnch.getCompoundTagAt(0).getInteger("id");
                     return id == SOUL_BOUND_ID;
+                }
+            }
+        }
+        return false;
+    }
+
+    public static boolean isTranslucencyBook(ItemStack book) {
+        if (TRANSLUCENCY_ID >= 0 && book.hasTagCompound()) {
+            NBTTagCompound bookData = book.stackTagCompound;
+            if (bookData.hasKey("StoredEnchantments")) {
+                NBTTagList bookEnch = bookData.getTagList("StoredEnchantments", NBT.TAG_COMPOUND);
+                if (!bookEnch.getCompoundTagAt(1).getBoolean("id")) // only pure book allowed
+                {
+                    int id = bookEnch.getCompoundTagAt(0).getInteger("id");
+                    return id == TRANSLUCENCY_ID;
                 }
             }
         }

--- a/src/main/java/com/darkona/adventurebackpack/util/EnchUtils.java
+++ b/src/main/java/com/darkona/adventurebackpack/util/EnchUtils.java
@@ -3,9 +3,6 @@ package com.darkona.adventurebackpack.util;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-import net.minecraftforge.common.util.Constants.NBT;
 
 import com.darkona.adventurebackpack.config.ConfigHandler;
 import com.darkona.adventurebackpack.reference.LoadedMods;
@@ -44,29 +41,25 @@ public final class EnchUtils {
     }
 
     public static boolean isSoulBounded(ItemStack stack) {
-        if (SOUL_BOUND_ID > 0)
-            return EnchantmentHelper.getEnchantmentLevel(SOUL_BOUND_ID, stack) > 0;
-        else
-            return false;
+        if (SOUL_BOUND_ID > 0) return EnchantmentHelper.getEnchantmentLevel(SOUL_BOUND_ID, stack) > 0;
+        else return false;
 
     }
 
     public static int getTranslucencyLevel(ItemStack stack) {
-        if (TRANSLUCENCY_ID > 0)
-            return EnchantmentHelper.getEnchantmentLevel(TRANSLUCENCY_ID, stack);
-        else
-            return 0;
+        if (TRANSLUCENCY_ID > 0) return EnchantmentHelper.getEnchantmentLevel(TRANSLUCENCY_ID, stack);
+        else return 0;
     }
 
     public static boolean isSoulBook(ItemStack book) {
-        if (EnchantmentHelper.getEnchantments(book).size() == 1){ // only pure soulbook allowed
+        if (EnchantmentHelper.getEnchantments(book).size() == 1) { // only pure soulbook allowed
             return EnchantmentHelper.getEnchantments(book).get(SOUL_BOUND_ID) != null;
         }
         return false;
     }
 
     public static boolean isTranslucencyBook(ItemStack book) {
-        if (EnchantmentHelper.getEnchantments(book).size() == 1){
+        if (EnchantmentHelper.getEnchantments(book).size() == 1) {
             return EnchantmentHelper.getEnchantments(book).get(TRANSLUCENCY_ID) != null;
         }
         return false;


### PR DESCRIPTION
Adventure backpacks (and copter pack / coal jetpack) can be hidden from rendering on the player's back through a new config option in the "graphics" section.  Additionally, if you don't want to disable it globally, you can instead use the Translucency II enchantment from Witching Gadgets to hide it permanently.  Translucency I was not necessary as the backpack already hides itself when you are invisible. 