### PR TITLE
milk no longer removes thaumcraft warp effect

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/fluids/effects/MilkEffect.java
+++ b/src/main/java/com/darkona/adventurebackpack/fluids/effects/MilkEffect.java
@@ -2,6 +2,8 @@ package com.darkona.adventurebackpack.fluids.effects;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidRegistry;
 
@@ -16,7 +18,7 @@ public class MilkEffect extends FluidEffect {
     @Override
     public void affectDrinker(World world, Entity entity) {
         if (entity instanceof EntityPlayer) {
-            ((EntityPlayer) entity).clearActivePotions();
+            ((EntityPlayer) entity).curePotionEffects(new ItemStack(Items.milk_bucket));
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18804
Thaumcraft effects caused by warp remove the default curative item (milk bucket), calling the curePotionEffects method only removes effects that should be cleared by milk instead of all.
To test this, you can't give yourself any of the effects (like unnatural hunger) with the /effect command. You have to give yourself warp and wait for the effect to be applied by the warp.