### PR TITLE
Adjust some GL for Angelica compat, to make items be not-the-sun

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/client/render/RendererItemAdventureBackpack.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/render/RendererItemAdventureBackpack.java
@@ -58,7 +58,7 @@ public class RendererItemAdventureBackpack implements IItemRenderer {
             case INVENTORY:
                 Minecraft.getMinecraft().renderEngine.bindTexture(modelTexture); {
                 GL11.glPushMatrix();
-                GL11.glColor4f(1, 1, 1, 128);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 
                 GL11.glPushMatrix();
                 GL11.glTranslatef(-0.5f, 0f, -0.5f);
@@ -81,7 +81,7 @@ public class RendererItemAdventureBackpack implements IItemRenderer {
             case ENTITY:
                 Minecraft.getMinecraft().renderEngine.bindTexture(modelTexture); {
                 GL11.glPushMatrix();
-                GL11.glColor4f(1, 1, 1, 128);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 
                 GL11.glPushMatrix();
                 GL11.glTranslatef(0f, 1f, 0f);
@@ -105,7 +105,7 @@ public class RendererItemAdventureBackpack implements IItemRenderer {
                 Minecraft.getMinecraft().renderEngine.bindTexture(modelTexture);
 
                 GL11.glPushMatrix();
-                GL11.glColor4f(1, 1, 1, 128);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 
                 GL11.glPushMatrix();
                 GL11.glTranslatef(0.8f, 0.8f, 0.0f);
@@ -132,7 +132,7 @@ public class RendererItemAdventureBackpack implements IItemRenderer {
                 Minecraft.getMinecraft().renderEngine.bindTexture(modelTexture);
 
                 GL11.glPushMatrix();
-                GL11.glColor4f(1, 1, 1, 128);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 
                 GL11.glPushMatrix();
                 GL11.glTranslatef(1f, 0.8f, 0.8f);

--- a/src/main/java/com/darkona/adventurebackpack/client/render/RendererItemAdventureHat.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/render/RendererItemAdventureHat.java
@@ -54,7 +54,7 @@ public class RendererItemAdventureHat implements IItemRenderer {
         switch (type) {
             case INVENTORY: {
                 GL11.glPushMatrix();
-                GL11.glColor4f(1, 1, 1, 128);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 
                 GL11.glPushMatrix();
                 GL11.glTranslatef(-0.5f, -1.0f, -0.5f);
@@ -76,7 +76,7 @@ public class RendererItemAdventureHat implements IItemRenderer {
             case ENTITY:
                 Minecraft.getMinecraft().renderEngine.bindTexture(modelTexture); {
                 GL11.glPushMatrix();
-                GL11.glColor4f(1, 1, 1, 128);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 
                 GL11.glPushMatrix();
                 GL11.glTranslatef(0f, 0f, 0f);
@@ -99,7 +99,7 @@ public class RendererItemAdventureHat implements IItemRenderer {
                 Minecraft.getMinecraft().renderEngine.bindTexture(modelTexture);
 
                 GL11.glPushMatrix();
-                GL11.glColor4f(1, 1, 1, 128);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
                 GL11.glPushMatrix();
                 GL11.glScalef(1.0f, 1.0f, 1.0f);
 
@@ -128,7 +128,7 @@ public class RendererItemAdventureHat implements IItemRenderer {
                 Minecraft.getMinecraft().renderEngine.bindTexture(modelTexture);
 
                 GL11.glPushMatrix();
-                GL11.glColor4f(1, 1, 1, 128);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 
                 GL11.glPushMatrix();
                 GL11.glTranslatef(-.1f, 0f, 0.0f);

--- a/src/main/java/com/darkona/adventurebackpack/client/render/RendererItemClockworkCrossbow.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/render/RendererItemClockworkCrossbow.java
@@ -34,7 +34,7 @@ public class RendererItemClockworkCrossbow implements IItemRenderer {
         switch (type) {
             case INVENTORY: {
                 GL11.glPushMatrix();
-                GL11.glColor4f(1, 1, 1, 128);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 
                 GL11.glPushMatrix();
                 GL11.glTranslatef(-0.5f, -.5f, -0.5f);
@@ -56,7 +56,7 @@ public class RendererItemClockworkCrossbow implements IItemRenderer {
             case ENTITY:
                 Minecraft.getMinecraft().renderEngine.bindTexture(modelTexture); {
                 GL11.glPushMatrix();
-                GL11.glColor4f(1, 1, 1, 128);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 
                 GL11.glPushMatrix();
                 GL11.glTranslatef(0f, .50f, 0f);
@@ -79,7 +79,7 @@ public class RendererItemClockworkCrossbow implements IItemRenderer {
                 Minecraft.getMinecraft().renderEngine.bindTexture(modelTexture);
 
                 GL11.glPushMatrix();
-                GL11.glColor4f(1, 1, 1, 128);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
                 GL11.glPushMatrix();
                 GL11.glScalef(1.2f, 1.2f, 1.2f);
 
@@ -102,7 +102,7 @@ public class RendererItemClockworkCrossbow implements IItemRenderer {
                 player = (EntityPlayer) data[1];
 
                 GL11.glPushMatrix();
-                GL11.glColor4f(1, 1, 1, 128);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
                 GL11.glRotatef(180, 0, 0, 1);
                 GL11.glScalef(1.2f, 1.2f, 1.2f);
 


### PR DESCRIPTION
Backpack, hat and crossbow were rendering as balls of light when the mod is used with Angelica. Changed the GL11.glColor4f values for each so that they render as expected. 

Built locally to test, and confirmed that it's working as intended now. 

Before: 
![Screenshot 2025-01-23 232002](https://github.com/user-attachments/assets/abf6e554-752f-47c4-a3eb-8ff934cfb8c2)


After: 
![Screenshot 2025-01-23 231600](https://github.com/user-attachments/assets/650ae5e8-aa16-4d05-8f3b-ad4f8d39423c)
