### PR TITLE
fix: crash when rendering component with damage 0

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/item/ItemComponent.java
+++ b/src/main/java/com/darkona/adventurebackpack/item/ItemComponent.java
@@ -27,6 +27,7 @@ public class ItemComponent extends ItemAB {
     private final HashMap<String, IIcon> componentIcons = new HashMap<>();
     private final String[] names = { "sleepingBag", "backpackTank", "hoseHead", "macheteHandle", "copterEngine",
             "copterBlades", "inflatableBoat", "inflatableBoatMotorized", "hydroBlades", };
+    private final static String defaultIconName = "copterBlades";
 
     public ItemComponent() {
         setNoRepair();
@@ -55,12 +56,21 @@ public class ItemComponent extends ItemAB {
     @Override
     @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamage(int damage) {
+        // Some places like the statistics menu render Items with metadata 0, which is not valid for this item,
+        // so just fall back to a valid icon.
+        if (damage < 1 || damage > names.length) return componentIcons.get(defaultIconName);
+
         return componentIcons.get(names[damage - 1]);
     }
 
     @Override
     public String getUnlocalizedName(ItemStack stack) {
-        return super.getUnlocalizedName(names[getDamage(stack) - 1]);
+        int damage = getDamage(stack);
+        // Some places like the statistics menu render Items with metadata 0, which is not valid for this item,
+        // so just fall back to the generic component item name.
+        if (damage < 1 || damage > names.length) return getUnlocalizedName();
+
+        return super.getUnlocalizedName(names[damage - 1]);
     }
 
     @Override


### PR DESCRIPTION
fix crash when rendering component with damage 0, such as in the vanilla statistics screen.
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19328

Before: Crash

After: 
![image](https://github.com/user-attachments/assets/66b5331f-0b36-49fb-a506-2631cea0142a)
The translation string for a generic component already existed, so that is used.
As the generic Icon, I chose the Copter Blades since the sleeping bag and tank are also things that exist outside of their role as a component, and the copter blades were IMO the most recognizable of the remaining ones.
![image](https://github.com/user-attachments/assets/a7efbb72-c5f2-45c2-9b2c-53fa6af5d573)
