### PR TITLE
Drop duplicated inventory tab rendering code

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,8 +1,8 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:waila:1.8.12:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.7.84-GTNH:dev")
+    api("com.github.GTNewHorizons:waila:1.9.0:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.8.8-GTNH:dev")
 
-    devOnlyNonPublishable("com.github.GTNewHorizons:TinkersConstruct:1.13.52-GTNH:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:TinkersConstruct:1.14.4-GTNH:dev")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.42'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.43'
 }
 
 

--- a/src/main/java/com/darkona/adventurebackpack/AdventureBackpack.java
+++ b/src/main/java/com/darkona/adventurebackpack/AdventureBackpack.java
@@ -35,7 +35,7 @@ import cpw.mods.fml.common.network.NetworkRegistry;
         name = ModInfo.MOD_NAME,
         version = ModInfo.MOD_VERSION,
         guiFactory = ModInfo.GUI_FACTORY_CLASS,
-        dependencies = "required-after:CodeChickenCore@[1.0.7.47,)")
+        dependencies = "required-after:CodeChickenCore@[1.0.7.47,);" + "after:TConstruct;")
 public class AdventureBackpack {
 
     @SidedProxy(clientSide = ModInfo.MOD_CLIENT_PROXY, serverSide = ModInfo.MOD_SERVER_PROXY)

--- a/src/main/java/com/darkona/adventurebackpack/util/TConstructTab.java
+++ b/src/main/java/com/darkona/adventurebackpack/util/TConstructTab.java
@@ -4,13 +4,8 @@ import java.util.List;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
-import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.entity.RenderItem;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-
-import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL12;
 
 import com.darkona.adventurebackpack.init.ModNetwork;
 import com.darkona.adventurebackpack.network.GUIPacket;
@@ -60,49 +55,9 @@ public class TConstructTab {
             return Wearing.isWearingWearable(Minecraft.getMinecraft().thePlayer);
         }
 
-        /**
-         * Draws this button to the screen. Code from TinkersConstruct and modified for dynamic and depth-enabled
-         * backpack rendering
-         */
         @Override
         public void drawButton(Minecraft mc, int mouseX, int mouseY) {
-            if (this.visible) {
-                ItemStack renderStack = Wearing.getWearingWearable(Minecraft.getMinecraft().thePlayer);
-                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-
-                int yTexPos = this.enabled ? 3 : 32;
-                int ySize = this.enabled ? 25 : 32;
-                int xOffset = this.id == 2 ? 0 : 1;
-                int yPos = this.yPosition + (this.enabled ? 3 : 0);
-
-                mc.renderEngine.bindTexture(texture);
-                this.drawTexturedModalRect(this.xPosition, yPos, xOffset * 28, yTexPos, 28, ySize);
-
-                RenderHelper.enableGUIStandardItemLighting();
-                this.zLevel = 100.0F;
-                itemRenderer.zLevel = 100.0F;
-                GL11.glEnable(GL11.GL_LIGHTING);
-                GL11.glEnable(GL12.GL_RESCALE_NORMAL);
-                GL11.glEnable(GL11.GL_DEPTH_TEST);
-                itemRenderer.renderItemAndEffectIntoGUI(
-                        mc.fontRenderer,
-                        mc.renderEngine,
-                        renderStack,
-                        xPosition + 6,
-                        yPosition + 8);
-                itemRenderer.renderItemOverlayIntoGUI(
-                        mc.fontRenderer,
-                        mc.renderEngine,
-                        renderStack,
-                        xPosition + 6,
-                        yPosition + 8);
-                GL11.glDisable(GL11.GL_DEPTH_TEST);
-                GL11.glDisable(GL11.GL_LIGHTING);
-                GL11.glEnable(GL11.GL_BLEND);
-                itemRenderer.zLevel = 0.0F;
-                this.zLevel = 0.0F;
-                RenderHelper.disableStandardItemLighting();
-            }
+            drawButton(mc, Wearing.getWearingWearable(mc.thePlayer), true);
         }
     }
 }


### PR DESCRIPTION
Move the inventory tab rendering code to TiCon.

Depends on https://github.com/GTNewHorizons/TinkersConstruct/pull/217 (that why it's currently set to draft)

addresses https://github.com/GTNewHorizons/TinkersConstruct/pull/211#issuecomment-3369351588