### PR TITLE
Add tooltip to equip/unequip button in GUIs

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/client/gui/GuiAdvBackpack.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/gui/GuiAdvBackpack.java
@@ -5,7 +5,6 @@ import java.util.List;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidTank;
@@ -26,6 +25,7 @@ import com.darkona.adventurebackpack.network.SleepingBagPacket;
 import com.darkona.adventurebackpack.reference.LoadedMods;
 import com.darkona.adventurebackpack.util.Resources;
 import com.darkona.adventurebackpack.util.TinkersUtils;
+import com.darkona.adventurebackpack.util.TipUtils;
 
 import codechicken.nei.guihook.GuiContainerManager;
 import codechicken.nei.guihook.IContainerTooltipHandler;
@@ -165,41 +165,35 @@ public class GuiAdvBackpack extends GuiWithTanks {
 
         @Override
         public List<String> handleTooltip(GuiContainer gui, int mouseX, int mouseY, List<String> currenttip) {
-            if (gui.getClass() != GuiAdvBackpack.class) return currenttip;
+            if (gui instanceof GuiAdvBackpack) {
+                GuiAdvBackpack backpackGui = (GuiAdvBackpack) gui;
 
-            GuiWithTanks backpackGui = (GuiWithTanks) gui;
+                if (GuiContainerManager.shouldShowTooltip(backpackGui) && currenttip.isEmpty()) {
+                    // Fluid tank tooltips
+                    if (tankLeft.inTank(backpackGui, mouseX, mouseY)) currenttip.addAll(tankLeft.getTankTooltip());
+                    if (tankRight.inTank(backpackGui, mouseX, mouseY)) currenttip.addAll(tankRight.getTankTooltip());
 
-            // Fluid tank tooltips
-            if (GuiContainerManager.shouldShowTooltip(gui) && currenttip.size() == 0) {
-                if (tankLeft.inTank(backpackGui, mouseX, mouseY)) currenttip.addAll(tankLeft.getTankTooltip());
-
-                if (tankRight.inTank(backpackGui, mouseX, mouseY)) currenttip.addAll(tankRight.getTankTooltip());
+                    // equip/unequip button
+                    if (backpackGui.source == Source.HOLDING && equipButton.inButton(backpackGui, mouseX, mouseY)) {
+                        currenttip.add(TipUtils.l10n("backpack.equip"));
+                    } else if (backpackGui.isBedButtonCase() && bedButton.inButton(backpackGui, mouseX, mouseY)) {
+                        currenttip.add(TipUtils.l10n("backpack.sleepingbag"));
+                    } else if (backpackGui.source == Source.WEARING
+                            && unequipButton.inButton(backpackGui, mouseX, mouseY)) {
+                                currenttip.add(TipUtils.l10n("backpack.unequip.key1"));
+                                currenttip.add(TipUtils.l10n("backpack.unequip.key2"));
+                            }
+                }
             }
 
             return currenttip;
         }
 
-        /**
-         * Required by IContainerTooltipHandler implementation but not needed here
-         */
-        @Override
-        public List<String> handleItemDisplayName(GuiContainer gui, ItemStack itemstack, List<String> currenttip) {
-            return currenttip;
-        }
-
-        /**
-         * Required by IContainerTooltipHandler implementation but not needed here
-         */
-        @Override
-        public List<String> handleItemTooltip(GuiContainer gui, ItemStack itemstack, int mousex, int mousey,
-                List<String> currenttip) {
-            return currenttip;
-        }
     }
 
     static {
         // Only instantiate TooltipHandler if enabled in config.
-        if (ConfigHandler.tanksHoveringText) {
+        if (ConfigHandler.showGuiTooltips) {
             GuiContainerManager.addTooltipHandler(new TooltipHandler());
         }
     }

--- a/src/main/java/com/darkona/adventurebackpack/client/gui/GuiCoalJetpack.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/gui/GuiCoalJetpack.java
@@ -1,5 +1,8 @@
 package com.darkona.adventurebackpack.client.gui;
 
+import java.util.List;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -14,6 +17,10 @@ import com.darkona.adventurebackpack.config.ConfigHandler;
 import com.darkona.adventurebackpack.inventory.ContainerJetpack;
 import com.darkona.adventurebackpack.inventory.InventoryCoalJetpack;
 import com.darkona.adventurebackpack.util.Resources;
+import com.darkona.adventurebackpack.util.TipUtils;
+
+import codechicken.nei.guihook.GuiContainerManager;
+import codechicken.nei.guihook.IContainerTooltipHandler;
 
 public class GuiCoalJetpack extends GuiWithTanks {
 
@@ -132,5 +139,38 @@ public class GuiCoalJetpack extends GuiWithTanks {
     @Override
     protected GuiImageButtonNormal getUnequipButton() {
         return unequipButton;
+    }
+
+    /**
+     * An instance of this class will handle tooltips for all instances of GuiAdvBackpack
+     */
+    public static class TooltipHandler implements IContainerTooltipHandler {
+
+        @Override
+        public List<String> handleTooltip(GuiContainer gui, int mouseX, int mouseY, List<String> currenttip) {
+            if (gui instanceof GuiCoalJetpack) {
+                GuiCoalJetpack backpackGui = (GuiCoalJetpack) gui;
+
+                if (GuiContainerManager.shouldShowTooltip(backpackGui) && currenttip.isEmpty()) {
+                    // equip/unequip button
+                    if (backpackGui.source == Source.HOLDING && equipButton.inButton(backpackGui, mouseX, mouseY)) {
+                        currenttip.add(TipUtils.l10n("jetpack.equip"));
+                    } else if (backpackGui.source == Source.WEARING
+                            && unequipButton.inButton(backpackGui, mouseX, mouseY)) {
+                                currenttip.add(TipUtils.l10n("jetpack.unequip"));
+                            }
+                }
+            }
+
+            return currenttip;
+        }
+
+    }
+
+    static {
+        // Only instantiate TooltipHandler if enabled in config.
+        if (ConfigHandler.showGuiTooltips) {
+            GuiContainerManager.addTooltipHandler(new GuiCoalJetpack.TooltipHandler());
+        }
     }
 }

--- a/src/main/java/com/darkona/adventurebackpack/client/gui/GuiCopterPack.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/gui/GuiCopterPack.java
@@ -1,5 +1,8 @@
 package com.darkona.adventurebackpack.client.gui;
 
+import java.util.List;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidTank;
@@ -13,6 +16,10 @@ import com.darkona.adventurebackpack.inventory.ContainerCopter;
 import com.darkona.adventurebackpack.inventory.InventoryCopterPack;
 import com.darkona.adventurebackpack.reference.GeneralReference;
 import com.darkona.adventurebackpack.util.Resources;
+import com.darkona.adventurebackpack.util.TipUtils;
+
+import codechicken.nei.guihook.GuiContainerManager;
+import codechicken.nei.guihook.IContainerTooltipHandler;
 
 public class GuiCopterPack extends GuiWithTanks {
 
@@ -100,5 +107,38 @@ public class GuiCopterPack extends GuiWithTanks {
     @Override
     protected GuiImageButtonNormal getUnequipButton() {
         return unequipButton;
+    }
+
+    /**
+     * An instance of this class will handle tooltips for all instances of GuiAdvBackpack
+     */
+    public static class TooltipHandler implements IContainerTooltipHandler {
+
+        @Override
+        public List<String> handleTooltip(GuiContainer gui, int mouseX, int mouseY, List<String> currenttip) {
+            if (gui instanceof GuiCopterPack) {
+                GuiCopterPack copterPackGui = (GuiCopterPack) gui;
+
+                if (GuiContainerManager.shouldShowTooltip(copterPackGui) && currenttip.isEmpty()) {
+                    // equip/unequip button
+                    if (copterPackGui.source == Source.HOLDING && equipButton.inButton(copterPackGui, mouseX, mouseY)) {
+                        currenttip.add(TipUtils.l10n("copter.equip"));
+                    } else if (copterPackGui.source == Source.WEARING
+                            && unequipButton.inButton(copterPackGui, mouseX, mouseY)) {
+                                currenttip.add(TipUtils.l10n("copter.unequip"));
+                            }
+                }
+            }
+
+            return currenttip;
+        }
+
+    }
+
+    static {
+        // Only instantiate TooltipHandler if enabled in config.
+        if (ConfigHandler.showGuiTooltips) {
+            GuiContainerManager.addTooltipHandler(new GuiCopterPack.TooltipHandler());
+        }
     }
 }

--- a/src/main/java/com/darkona/adventurebackpack/config/ConfigHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/config/ConfigHandler.java
@@ -29,7 +29,7 @@ public class ConfigHandler {
     public static boolean enableTemperatureBar = false;
     public static boolean enableToolsRender = true;
     public static int typeTankRender = 2;
-    public static boolean tanksHoveringText = true;
+    public static boolean showGuiTooltips = true;
 
     public static boolean statusOverlay = true;
     public static boolean statusOverlayLeft = true;
@@ -160,7 +160,7 @@ public class ConfigHandler {
                 "graphics",
                 true,
                 "Enable rendering for tools in the backpack tool slots");
-        tanksHoveringText = config.getBoolean("Hovering Text", "graphics", true, "Show hovering text on fluid tanks?");
+        showGuiTooltips = config.getBoolean("Hovering Text", "graphics", true, "Show tooltips in GUIs?");
 
         // Graphics.Status
         statusOverlay = config

--- a/src/main/resources/assets/adventurebackpack/lang/en_US.lang
+++ b/src/main/resources/assets/adventurebackpack/lang/en_US.lang
@@ -98,29 +98,37 @@ adventurebackpack:tooltips.backpack.tank.left=Left Tank
 adventurebackpack:tooltips.backpack.tank.right=Right Tank
 adventurebackpack:tooltips.backpack.cycling=Tool Cycling
 adventurebackpack:tooltips.backpack.cycling.key1=while wearing
-adventurebackpack:tooltips.backpack.cycling.key2=backpack, for turn cycling
+adventurebackpack:tooltips.backpack.cycling.key2=Backpack to turn tool cycling
 adventurebackpack:tooltips.backpack.vision=Night Vision
 adventurebackpack:tooltips.backpack.vision.key1=while wearing
-adventurebackpack:tooltips.backpack.vision.key2=backpack, for turn nightvision
+adventurebackpack:tooltips.backpack.vision.key2=Backpack to turn night vision
+adventurebackpack:tooltips.backpack.equip=Shoulder Backpack
+adventurebackpack:tooltips.backpack.unequip.key1=Unshoulder Backpack
+adventurebackpack:tooltips.backpack.unequip.key2=§7Hold Shift: use Sleeping Bag§r
+adventurebackpack:tooltips.backpack.sleepingbag=Use Sleeping Bag
 
 adventurebackpack:tooltips.jetpack.fuel=Fuel
 adventurebackpack:tooltips.jetpack.tank.water=Left Tank
 adventurebackpack:tooltips.jetpack.tank.steam=Right Tank
 adventurebackpack:tooltips.jetpack.key.onoff1=while wearing
-adventurebackpack:tooltips.jetpack.key.onoff2=jetpack, for turn it
+adventurebackpack:tooltips.jetpack.key.onoff2=jetpack to turn it
+adventurebackpack:tooltips.jetpack.equip=Shoulder Coal Jetpack
+adventurebackpack:tooltips.jetpack.unequip=Unshoulder Coal Jetpack
 
 adventurebackpack:tooltips.copter.tank.fuel=Fuel Tank
 adventurebackpack:tooltips.copter.rate.fuel=Fuel consumption rate
 adventurebackpack:tooltips.copter.key.onoff1=while wearing
-adventurebackpack:tooltips.copter.key.onoff2=copterpack, for turn it
+adventurebackpack:tooltips.copter.key.onoff2=Copter Pack to turn it
 adventurebackpack:tooltips.copter.key.hover1=during flight to
-adventurebackpack:tooltips.copter.key.hover2=switch hover mode
+adventurebackpack:tooltips.copter.key.hover2=toggle hover mode
+adventurebackpack:tooltips.copter.equip=Shoulder Copter Pack
+adventurebackpack:tooltips.copter.unequip=Unshoulder Copter Pack
 
 adventurebackpack:tooltips.hose.key.header=While holding Hose:
 adventurebackpack:tooltips.hose.key.tank=to change active tank
 adventurebackpack:tooltips.hose.key.mode=to change mode
 adventurebackpack:tooltips.hose.dump1=Put Hose into bucketOut slot of wearable pack
-adventurebackpack:tooltips.hose.dump2=to empty corresponded tank
+adventurebackpack:tooltips.hose.dump2=to empty corresponding tank
 adventurebackpack:tooltips.hose.dump.warn=WARNING! Fluid will be dumped and lost. Forever.
 
 ## Skins


### PR DESCRIPTION
These additional tooltips should clarify what the equip/unequip button does in the GUI since it's icon-only. More importantly, it hints at how to activate the Sleeping Bag without putting the backpack down onto the ground first.

<img width="854" height="480" alt="2025-10-11_11 58 39" src="https://github.com/user-attachments/assets/85fe8598-562b-4de2-ba37-755d4673487c" />

Additionally, I've reworded some existing tooltips.