### PR TITLE
Support Witchery's Sticky Items potion

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/client/render/RendererWearableEquipped.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/render/RendererWearableEquipped.java
@@ -15,7 +15,7 @@ import org.lwjgl.opengl.GL12;
 
 import com.darkona.adventurebackpack.config.ConfigHandler;
 import com.darkona.adventurebackpack.item.IBackWearableItem;
-import com.darkona.adventurebackpack.util.EnchUtils;
+import com.darkona.adventurebackpack.util.PotionAndEnchantUtils;
 import com.darkona.adventurebackpack.util.Wearing;
 
 public class RendererWearableEquipped extends RendererLivingEntity {
@@ -42,7 +42,7 @@ public class RendererWearableEquipped extends RendererLivingEntity {
         if (!ConfigHandler.enableBackRendering) {
             return;
         }
-        if (EnchUtils.getTranslucencyLevel(wearable) == 2) {
+        if (PotionAndEnchantUtils.getTranslucencyLevel(wearable) == 2) {
             return;
         }
         GL11.glPushAttrib(GL11.GL_TRANSFORM_BIT);

--- a/src/main/java/com/darkona/adventurebackpack/config/ConfigHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/config/ConfigHandler.java
@@ -15,6 +15,7 @@ public class ConfigHandler {
 
     public static boolean allowSoulBound = true;
     public static boolean allowTranslucency = true;
+    public static boolean allowStickyItems = true;
     public static boolean backpackDeathPlace = true;
     public static boolean backpackAbilities = true;
     public static boolean enableCampfireSpawn = false;
@@ -104,6 +105,11 @@ public class ConfigHandler {
                 .getBoolean("Allow SoulBound", "gameplay", true, "Allow SoulBound enchant on wearable packs");
         allowTranslucency = config
                 .getBoolean("Allow Translucency", "gameplay", true, "Allow Translucency enchant on wearable packs");
+        allowStickyItems = config.getBoolean(
+                "Allow Sticky Items",
+                "gameplay",
+                true,
+                "Allow Sticky Items potion effect on wearable packs");
         backpackAbilities = config.getBoolean(
                 "Backpack Abilities",
                 "gameplay",

--- a/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
@@ -35,8 +35,8 @@ import com.darkona.adventurebackpack.item.ItemAdventureBackpack;
 import com.darkona.adventurebackpack.playerProperties.BackpackProperty;
 import com.darkona.adventurebackpack.proxy.ServerProxy;
 import com.darkona.adventurebackpack.reference.BackpackTypes;
-import com.darkona.adventurebackpack.util.PotionAndEnchantUtils;
 import com.darkona.adventurebackpack.util.LogHelper;
+import com.darkona.adventurebackpack.util.PotionAndEnchantUtils;
 import com.darkona.adventurebackpack.util.Wearing;
 
 import cpw.mods.fml.common.eventhandler.Event;
@@ -170,7 +170,8 @@ public class PlayerEventHandler {
                         player.worldObj.createExplosion(player, player.posX, player.posY, player.posZ, 4.0F, false);
                     }
 
-                    if (player.getEntityWorld().getGameRules().getGameRuleBooleanValue("keepInventory")) {
+                    if (player.getEntityWorld().getGameRules().getGameRuleBooleanValue("keepInventory")
+                            || PotionAndEnchantUtils.hasStickyItems(player)) {
                         ((IBackWearableItem) props.getWearable().getItem())
                                 .onPlayerDeath(player.worldObj, player, props.getWearable());
                         ServerProxy.storePlayerProps(player);

--- a/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
@@ -35,7 +35,7 @@ import com.darkona.adventurebackpack.item.ItemAdventureBackpack;
 import com.darkona.adventurebackpack.playerProperties.BackpackProperty;
 import com.darkona.adventurebackpack.proxy.ServerProxy;
 import com.darkona.adventurebackpack.reference.BackpackTypes;
-import com.darkona.adventurebackpack.util.EnchUtils;
+import com.darkona.adventurebackpack.util.PotionAndEnchantUtils;
 import com.darkona.adventurebackpack.util.LogHelper;
 import com.darkona.adventurebackpack.util.Wearing;
 
@@ -189,7 +189,7 @@ public class PlayerEventHandler {
             ItemStack pack = Wearing.getWearingWearable(player);
             BackpackProperty props = BackpackProperty.get(player);
 
-            if (EnchUtils.isSoulBounded(pack)
+            if (PotionAndEnchantUtils.isSoulBounded(pack)
                     || (ConfigHandler.backpackDeathPlace && pack.getItem() instanceof ItemAdventureBackpack)) {
                 ((IBackWearableItem) props.getWearable().getItem())
                         .onPlayerDeath(player.worldObj, player, props.getWearable());

--- a/src/main/java/com/darkona/adventurebackpack/item/ItemAdventure.java
+++ b/src/main/java/com/darkona/adventurebackpack/item/ItemAdventure.java
@@ -5,7 +5,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 
 import com.darkona.adventurebackpack.inventory.ContainerAdventure;
-import com.darkona.adventurebackpack.util.EnchUtils;
+import com.darkona.adventurebackpack.util.PotionAndEnchantUtils;
 
 @SuppressWarnings("WeakerAccess")
 public abstract class ItemAdventure extends ItemAB implements IBackWearableItem {
@@ -41,7 +41,7 @@ public abstract class ItemAdventure extends ItemAB implements IBackWearableItem 
 
     @Override
     public boolean isBookEnchantable(ItemStack stack, ItemStack book) {
-        return EnchUtils.isSoulBook(book) || EnchUtils.isTranslucencyBook(book);
+        return PotionAndEnchantUtils.isSoulBook(book) || PotionAndEnchantUtils.isTranslucencyBook(book);
 
     }
 }

--- a/src/main/java/com/darkona/adventurebackpack/item/ItemAdventureBackpack.java
+++ b/src/main/java/com/darkona/adventurebackpack/item/ItemAdventureBackpack.java
@@ -42,7 +42,7 @@ import com.darkona.adventurebackpack.proxy.ClientProxy;
 import com.darkona.adventurebackpack.reference.BackpackTypes;
 import com.darkona.adventurebackpack.util.BackpackUtils;
 import com.darkona.adventurebackpack.util.CoordsUtils;
-import com.darkona.adventurebackpack.util.EnchUtils;
+import com.darkona.adventurebackpack.util.PotionAndEnchantUtils;
 import com.darkona.adventurebackpack.util.Resources;
 import com.darkona.adventurebackpack.util.TipUtils;
 import com.darkona.adventurebackpack.util.Utils;
@@ -135,7 +135,7 @@ public class ItemAdventureBackpack extends ItemAdventure {
     @Override
     public void onPlayerDeath(World world, EntityPlayer player, ItemStack stack) {
         if (world.isRemote || !ConfigHandler.backpackDeathPlace
-                || EnchUtils.isSoulBounded(stack)
+                || PotionAndEnchantUtils.isSoulBounded(stack)
                 || player.getEntityWorld().getGameRules().getGameRuleBooleanValue("keepInventory")) {
             return;
         }

--- a/src/main/java/com/darkona/adventurebackpack/item/ItemAdventureBackpack.java
+++ b/src/main/java/com/darkona/adventurebackpack/item/ItemAdventureBackpack.java
@@ -136,6 +136,7 @@ public class ItemAdventureBackpack extends ItemAdventure {
     public void onPlayerDeath(World world, EntityPlayer player, ItemStack stack) {
         if (world.isRemote || !ConfigHandler.backpackDeathPlace
                 || PotionAndEnchantUtils.isSoulBounded(stack)
+                || PotionAndEnchantUtils.hasStickyItems(player)
                 || player.getEntityWorld().getGameRules().getGameRuleBooleanValue("keepInventory")) {
             return;
         }

--- a/src/main/java/com/darkona/adventurebackpack/reference/LoadedMods.java
+++ b/src/main/java/com/darkona/adventurebackpack/reference/LoadedMods.java
@@ -19,6 +19,7 @@ public final class LoadedMods {
     public static final boolean THAUMCRAFT = registerMod("Thaumcraft");
     public static final boolean WAILA = registerMod("waila");
     public static final boolean HUNGEROVERHAUL = registerMod("HungerOverhaul");
+    public static final boolean WITCHERY = registerMod("witchery");
     public static final boolean WITCHINGGADGETS = registerMod("WitchingGadgets");
 
     private LoadedMods() {}

--- a/src/main/java/com/darkona/adventurebackpack/util/PotionAndEnchantUtils.java
+++ b/src/main/java/com/darkona/adventurebackpack/util/PotionAndEnchantUtils.java
@@ -2,7 +2,9 @@ package com.darkona.adventurebackpack.util;
 
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.potion.Potion;
 
 import com.darkona.adventurebackpack.config.ConfigHandler;
 import com.darkona.adventurebackpack.reference.LoadedMods;
@@ -14,6 +16,7 @@ public final class PotionAndEnchantUtils {
     // -1 - enchantment not found
     private static final int SOUL_BOUND_ID = setSoulBoundID();
     private static final int TRANSLUCENCY_ID = setTranslucencyID();
+    private static final int STICKY_ITEMS_ID = setStickyItemsID();
 
     private PotionAndEnchantUtils() {}
 
@@ -35,6 +38,17 @@ public final class PotionAndEnchantUtils {
 
         for (Enchantment ench : Enchantment.enchantmentsList)
             if (ench != null && ench.getName().equals("enchantment.wg.invisibleGear")) return ench.effectId;
+
+        return -1;
+    }
+
+    private static int setStickyItemsID() {
+        if (!ConfigHandler.allowStickyItems) return -3;
+
+        if (!LoadedMods.WITCHERY) return -2;
+
+        for (Potion potion : Potion.potionTypes)
+            if (potion != null && potion.getName().equals("witchery:potion.keepinventory")) return potion.getId();
 
         return -1;
     }
@@ -61,5 +75,9 @@ public final class PotionAndEnchantUtils {
             return EnchantmentHelper.getEnchantments(book).get(TRANSLUCENCY_ID) != null;
         }
         return false;
+    }
+
+    public static boolean hasStickyItems(EntityPlayer player) {
+        return (STICKY_ITEMS_ID > 0) && player.isPotionActive(STICKY_ITEMS_ID);
     }
 }

--- a/src/main/java/com/darkona/adventurebackpack/util/PotionAndEnchantUtils.java
+++ b/src/main/java/com/darkona/adventurebackpack/util/PotionAndEnchantUtils.java
@@ -7,16 +7,15 @@ import net.minecraft.item.ItemStack;
 import com.darkona.adventurebackpack.config.ConfigHandler;
 import com.darkona.adventurebackpack.reference.LoadedMods;
 
-public final class EnchUtils {
+public final class PotionAndEnchantUtils {
 
     // -3 - disabled by config
-    // -2 - EnderIO not found
+    // -2 - mod not found
     // -1 - enchantment not found
     private static final int SOUL_BOUND_ID = setSoulBoundID();
-
     private static final int TRANSLUCENCY_ID = setTranslucencyID();
 
-    private EnchUtils() {}
+    private PotionAndEnchantUtils() {}
 
     private static int setSoulBoundID() {
         if (!ConfigHandler.allowSoulBound) return -3;
@@ -43,7 +42,6 @@ public final class EnchUtils {
     public static boolean isSoulBounded(ItemStack stack) {
         if (SOUL_BOUND_ID > 0) return EnchantmentHelper.getEnchantmentLevel(SOUL_BOUND_ID, stack) > 0;
         else return false;
-
     }
 
     public static int getTranslucencyLevel(ItemStack stack) {


### PR DESCRIPTION
The Sticky Items potion effect allows players to keep their inventory upon death. Support for this was missing for worn Backpacks.

implements half of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21819