### PR TITLE
Remove Villager backpack trade from Villagers that locks trading till MV/Alum

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/config/ConfigHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/config/ConfigHandler.java
@@ -87,6 +87,7 @@ public class ConfigHandler {
     public static boolean allowBonusGen = false;
     public static boolean allowGolemGen = true;
     public static boolean allowPigmanGen = false;
+    public static boolean disableVillagerTrade = true;
 
     public static boolean chatSpam = true;
 
@@ -331,6 +332,8 @@ public class ConfigHandler {
                 "worldgen",
                 false,
                 "Allow generation of Pigman Backpacks in dungeon loot and villager trades");
+        disableVillagerTrade = config
+                .getBoolean("Disable Villager Trade", "worldgen", true, "Disables trade for Villager Backpacks");
 
         // Experimental
         bossBarIndent = config.getInt(

--- a/src/main/java/com/darkona/adventurebackpack/init/ModWorldGen.java
+++ b/src/main/java/com/darkona/adventurebackpack/init/ModWorldGen.java
@@ -25,7 +25,7 @@ import cpw.mods.fml.common.registry.VillagerRegistry;
 public class ModWorldGen {
 
     public static void init() {
-        {
+        if (!ConfigHandler.disableVillagerTrade) {
             ItemStack backpack = BackpackUtils.createBackpackStack(VILLAGER);
             VillagerRegistry.instance().registerVillageTradeHandler(1, new ModWorldGen.TradeHandler(backpack));
             VillagerRegistry.instance().registerVillageTradeHandler(2, new ModWorldGen.TradeHandler(backpack));

--- a/src/main/java/com/darkona/adventurebackpack/init/recipes/BackpackRecipesList.java
+++ b/src/main/java/com/darkona/adventurebackpack/init/recipes/BackpackRecipesList.java
@@ -514,7 +514,7 @@ public class BackpackRecipesList {
                 "DaD",
                 "CEC",
                 'L',
-                Blocks.log,
+                new ItemStack(Blocks.log, 1, 0),
                 'G',
                 Blocks.glass,
                 'D',
@@ -522,7 +522,7 @@ public class BackpackRecipesList {
                 'a',
                 backpack,
                 'C',
-                "cobblestone",
+                Blocks.cobblestone,
                 'E',
                 Blocks.emerald_block);
     }

--- a/src/main/java/com/darkona/adventurebackpack/init/recipes/BackpackRecipesList.java
+++ b/src/main/java/com/darkona/adventurebackpack/init/recipes/BackpackRecipesList.java
@@ -508,6 +508,23 @@ public class BackpackRecipesList {
         Squid = reviewRecipe("BIB", "IaI", "BIB", 'a', backpack, 'B', woolBlue, 'I', new ItemStack(Items.dye, 1, 0));
 
         Sponge = reviewRecipe(covered, 'X', Blocks.sponge, 'a', backpack);
+
+        Villager = reviewRecipe(
+                "LGL",
+                "DaD",
+                "CEC",
+                'L',
+                Blocks.log,
+                'G',
+                Blocks.glass,
+                'D',
+                Items.wooden_door,
+                'a',
+                backpack,
+                'C',
+                "cobblestone",
+                'E',
+                Blocks.emerald_block);
     }
 
     public final Object[] Silverfish;
@@ -581,6 +598,7 @@ public class BackpackRecipesList {
     public final Object[] Yellow;
     public final Object[] Zombie;
     public final Object[] ModdedNetwork;
+    public final Object[] Villager;
 
     public static Object[] reviewRecipe(Object... objects) {
         return objects;


### PR DESCRIPTION
Adds config that by default disables trade and adds crafting recipe : 
<img width="776" height="389" alt="image" src="https://github.com/user-attachments/assets/dc67b26d-6470-45e9-8569-0e7b9d585a1f" />

Backpack in itself is purely decorative, a very common trade to occur and effectively block Villager till ~MV, which is unfun and very annoying for challenge runs, and for regular runs already too far where Villager trading is obsolete.
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23302