### PR TITLE
Allow scroll-wheel item transfer in backpack GUI

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/client/gui/GuiWithTanks.java
+++ b/src/main/java/com/darkona/adventurebackpack/client/gui/GuiWithTanks.java
@@ -9,6 +9,8 @@ import org.lwjgl.input.Mouse;
 import com.darkona.adventurebackpack.common.Constants.Source;
 import com.darkona.adventurebackpack.config.Keybindings;
 import com.darkona.adventurebackpack.init.ModNetwork;
+import com.darkona.adventurebackpack.inventory.ContainerAdventure;
+import com.darkona.adventurebackpack.inventory.SlotFluid;
 import com.darkona.adventurebackpack.network.EquipUnequipBackWearablePacket;
 import com.darkona.adventurebackpack.reference.LoadedMods;
 import com.darkona.adventurebackpack.util.TConstructTab;
@@ -68,19 +70,19 @@ public abstract class GuiWithTanks extends GuiContainer {
 
     @Override
     public void handleMouseInput() {
-        if (Mouse.getEventDWheel() != 0) {
-            int i = Mouse.getEventX() * this.width / this.mc.displayWidth;
-            int j = this.height - Mouse.getEventY() * this.height / this.mc.displayHeight - 1;
-            int marginX = (width - xSize) / 2;
-            int marginY = (height - ySize) / 2;
+        if (Mouse.getEventDWheel() != 0 && theSlot instanceof SlotFluid) {
+            return; // fluid slot processing is server-only, scroll would desync
+        }
 
-            if (i > marginX && i < marginX + xSize) {
-                if (j > marginY && j < marginY + ySize) {
-                    return;
-                    // forbid mouseWheel when mouse over our GUI,
-                    // Shift+Wheel on stacks of fluid containers places them to clients bucket slots, causes desync
-                }
+        // skip fluid slot routing on scroll so containers go to regular inventory client-side
+        if (Mouse.getEventDWheel() != 0 && inventorySlots instanceof ContainerAdventure) {
+            ((ContainerAdventure) inventorySlots).skipFluidSlots = true;
+            try {
+                super.handleMouseInput();
+            } finally {
+                ((ContainerAdventure) inventorySlots).skipFluidSlots = false;
             }
+            return;
         }
 
         super.handleMouseInput();

--- a/src/main/java/com/darkona/adventurebackpack/inventory/ContainerAdventure.java
+++ b/src/main/java/com/darkona/adventurebackpack/inventory/ContainerAdventure.java
@@ -28,6 +28,7 @@ public abstract class ContainerAdventure extends Container {
     private final int[] fluidsAmount;
     private int itemsCount;
     private boolean requestedUpdate;
+    public boolean skipFluidSlots;
 
     protected ContainerAdventure(EntityPlayer player, IInventoryTanks inventory, Source source) {
         this.player = player;

--- a/src/main/java/com/darkona/adventurebackpack/inventory/ContainerBackpack.java
+++ b/src/main/java/com/darkona/adventurebackpack/inventory/ContainerBackpack.java
@@ -113,7 +113,7 @@ public class ContainerBackpack extends ContainerAdventure {
     protected boolean transferStackToPack(ItemStack stack) {
         if (SlotTool.isValidTool(stack)) {
             if (!mergeToolSlot(stack)) if (SlotBackpack.isValidItem(stack)) return mergeBackpackInv(stack);
-        } else if (SlotFluid.isContainer(stack) && !isHoldingSpace()) {
+        } else if (SlotFluid.isContainer(stack) && !isHoldingSpace() && !skipFluidSlots) {
             return transferFluidContainer(stack);
         } else if (SlotBackpack.isValidItem(stack)) {
             return mergeBackpackInv(stack);

--- a/src/main/java/com/darkona/adventurebackpack/inventory/ContainerCopter.java
+++ b/src/main/java/com/darkona/adventurebackpack/inventory/ContainerCopter.java
@@ -29,7 +29,7 @@ public class ContainerCopter extends ContainerAdventure {
 
     @Override
     public boolean transferStackToPack(ItemStack stack) {
-        if (SlotFluid.isContainer(stack)) {
+        if (SlotFluid.isContainer(stack) && !skipFluidSlots) {
             FluidTank fuelTank = ((InventoryCopterPack) inventory).getFuelTank();
             ItemStack stackOut = getSlot(COPTER_INV_START + 1).getStack();
 

--- a/src/main/java/com/darkona/adventurebackpack/inventory/ContainerJetpack.java
+++ b/src/main/java/com/darkona/adventurebackpack/inventory/ContainerJetpack.java
@@ -45,7 +45,7 @@ public class ContainerJetpack extends ContainerAdventure {
 
     @Override
     public boolean transferStackToPack(ItemStack stack) {
-        if (SlotFluid.isContainer(stack)) {
+        if (SlotFluid.isContainer(stack) && !skipFluidSlots) {
             FluidTank waterTank = ((InventoryCoalJetpack) inventory).getWaterTank();
             ItemStack stackOut = getSlot(JETPACK_INV_START + 1).getStack();
 

--- a/src/main/resources/META-INF/adventurebackpack_at.cfg
+++ b/src/main/resources/META-INF/adventurebackpack_at.cfg
@@ -1,1 +1,2 @@
 protected net.minecraft.inventory.InventoryCrafting field_70466_a # stackList
+protected net.minecraft.client.gui.inventory.GuiContainer field_147006_u # theSlot


### PR DESCRIPTION
The backpack GUI was blocking all scroll wheel events over the container to work around a fluid slot desync. This prevented MouseTweaks scroll-to-transfer feature from working entirely.

The restriction has been narrowed to apply only to fluid slots directly. Additionally, a flag was introduced so that fluid containers are routed to the regular backpack inventory during scrolling instead of bucket slots.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24192