### PR TITLE
Fix NoClassDefFoundError for Tinkers' Construct integration

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/inventory/SlotCraftResult.java
+++ b/src/main/java/com/darkona/adventurebackpack/inventory/SlotCraftResult.java
@@ -6,8 +6,7 @@ import net.minecraft.inventory.SlotCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
-import tconstruct.library.modifier.IModifyable;
-import tconstruct.library.tools.AbilityHelper;
+import com.darkona.adventurebackpack.util.TinkersUtils;
 
 public class SlotCraftResult extends SlotCrafting {
 
@@ -23,9 +22,9 @@ public class SlotCraftResult extends SlotCrafting {
     public void onPickupFromSlot(EntityPlayer player, ItemStack stack) {
         eventHandler.syncCraftMatrixWithInventory(true); // pre craft sync
         ItemStack tool = eventHandler.craftMatrix.getStackInSlot(4);
-        if (stack.getItem() instanceof IModifyable && tool != null && tool.getItem() instanceof IModifyable) {
-            IModifyable modifyable = (IModifyable) stack.getItem();
-            NBTTagCompound tags = stack.getTagCompound().getCompoundTag(modifyable.getBaseTagName());
+        if (TinkersUtils.isModifyable(stack) && TinkersUtils.isModifyable(tool)) {
+            String tagName = TinkersUtils.getBaseTagName(stack);
+            NBTTagCompound tags = stack.getTagCompound().getCompoundTag(tagName);
             int[] toRemoveArray = tags.hasKey("ToRemove") ? tags.getIntArray("ToRemove") : null;
             int toRemoveIndex = 0;
             IInventory inventory = eventHandler.craftMatrix;
@@ -52,7 +51,7 @@ public class SlotCraftResult extends SlotCrafting {
                     player.posZ,
                     "tinker:little_saw",
                     1.0F,
-                    (AbilityHelper.random.nextFloat() - AbilityHelper.random.nextFloat()) * 0.2F + 1.0F);
+                    (player.worldObj.rand.nextFloat() - player.worldObj.rand.nextFloat()) * 0.2F + 1.0F);
         } else {
             super.onPickupFromSlot(player, stack);
         }

--- a/src/main/java/com/darkona/adventurebackpack/util/TinkersUtils.java
+++ b/src/main/java/com/darkona/adventurebackpack/util/TinkersUtils.java
@@ -37,11 +37,22 @@ public final class TinkersUtils {
     private static Class<?> craftingStation;
     private static Object craftingStationInstance;
 
+    private static final String CLASS_IMODIFYABLE = "tconstruct.library.modifier.IModifyable";
+    private static Class<?> modifyableClass;
+    private static java.lang.reflect.Method getBaseTagNameMethod;
+
     private TinkersUtils() {}
 
     static {
         if (LoadedMods.TCONSTRUCT) {
             createCraftingStationInstance();
+
+            try {
+                modifyableClass = Class.forName(CLASS_IMODIFYABLE);
+                getBaseTagNameMethod = modifyableClass.getMethod("getBaseTagName");
+            } catch (Exception e) {
+                LogHelper.error("Error getting Tinkers IModifyable class or getBaseTagName method: " + e);
+            }
         }
     }
 
@@ -71,6 +82,25 @@ public final class TinkersUtils {
             invPlayer = Minecraft.getMinecraft().thePlayer.inventory;
         }
         return invPlayer;
+    }
+
+    public static boolean isModifyable(ItemStack stack) {
+        if (!LoadedMods.TCONSTRUCT || stack == null || stack.getItem() == null || modifyableClass == null) return false;
+        return modifyableClass.isInstance(stack.getItem());
+    }
+
+    public static String getBaseTagName(ItemStack stack) {
+        if (!LoadedMods.TCONSTRUCT || stack == null
+                || stack.getItem() == null
+                || modifyableClass == null
+                || getBaseTagNameMethod == null)
+            return "InfiTool";
+        try {
+            if (modifyableClass.isInstance(stack.getItem())) {
+                return (String) getBaseTagNameMethod.invoke(stack.getItem());
+            }
+        } catch (Exception e) {}
+        return "InfiTool";
     }
 
     public static boolean isToolOrWeapon(@Nullable ItemStack stack) {


### PR DESCRIPTION
## Summary
When crafting without Tinkers' Construct installed the game would crash due to trying to use `tconstruct.library.modifier.IModifyable` and `tconstruct.library.tools.AbilityHelper`  in `SlotCraftResult.java`.
For `IModifyable` I have changed it to use reflection in new helper methods in `TinkersUtils.java`.
As for `AbilityHelper.random` i replaced it with the world standard `Random` instance.
Tested it both with and without Tinkers' Construct installed.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge