### PR TITLE
Fix backpack dimension/death loss

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
+++ b/src/main/java/com/darkona/adventurebackpack/handlers/PlayerEventHandler.java
@@ -12,15 +12,14 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemNameTag;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraftforge.event.entity.EntityEvent;
-import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.player.EntityInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerDropsEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent.Clone;
 import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
 
 import com.darkona.adventurebackpack.block.BlockSleepingBag;
@@ -33,7 +32,6 @@ import com.darkona.adventurebackpack.init.ModItems;
 import com.darkona.adventurebackpack.item.IBackWearableItem;
 import com.darkona.adventurebackpack.item.ItemAdventureBackpack;
 import com.darkona.adventurebackpack.playerProperties.BackpackProperty;
-import com.darkona.adventurebackpack.proxy.ServerProxy;
 import com.darkona.adventurebackpack.reference.BackpackTypes;
 import com.darkona.adventurebackpack.util.LogHelper;
 import com.darkona.adventurebackpack.util.PotionAndEnchantUtils;
@@ -62,15 +60,12 @@ public class PlayerEventHandler {
     }
 
     @SubscribeEvent
-    public void joinPlayer(EntityJoinWorldEvent event) {
-        if (!event.world.isRemote && event.entity instanceof EntityPlayer) {
-            EntityPlayer player = (EntityPlayer) event.entity;
-            NBTTagCompound playerData = ServerProxy.extractPlayerProps(player.getUniqueID());
-            if (playerData != null) {
-                BackpackProperty.get(player).loadNBTData(playerData);
-                BackpackProperty.sync(player);
-                LogHelper.info("Stored properties retrieved");
-            }
+    public void clonePlayer(Clone event) {
+        BackpackProperty original = BackpackProperty.get(event.original);
+        BackpackProperty clone = BackpackProperty.get(event.entityPlayer);
+
+        if (original != null && clone != null && original != clone) {
+            clone.loadNBTData(original.getData());
         }
     }
 
@@ -174,7 +169,6 @@ public class PlayerEventHandler {
                             || PotionAndEnchantUtils.hasStickyItems(player)) {
                         ((IBackWearableItem) props.getWearable().getItem())
                                 .onPlayerDeath(player.worldObj, player, props.getWearable());
-                        ServerProxy.storePlayerProps(player);
                     }
                 }
             }
@@ -194,7 +188,6 @@ public class PlayerEventHandler {
                     || (ConfigHandler.backpackDeathPlace && pack.getItem() instanceof ItemAdventureBackpack)) {
                 ((IBackWearableItem) props.getWearable().getItem())
                         .onPlayerDeath(player.worldObj, player, props.getWearable());
-                ServerProxy.storePlayerProps(player);
             } else {
                 event.drops.add(new EntityItem(player.worldObj, player.posX, player.posY, player.posZ, pack));
                 props.setWearable(null);

--- a/src/main/java/com/darkona/adventurebackpack/playerProperties/BackpackProperty.java
+++ b/src/main/java/com/darkona/adventurebackpack/playerProperties/BackpackProperty.java
@@ -52,10 +52,13 @@ public class BackpackProperty implements IExtendedEntityProperties {
 
     private static void syncToNear(EntityPlayerMP player) {
         try {
-            player.getServerForPlayer().getEntityTracker().func_151248_b(
-                    player,
-                    ModNetwork.net.getPacketFrom(
-                            new SyncPropertiesPacket.Message(player.getEntityId(), get(player).getData())));
+            SyncPropertiesPacket.Message message = new SyncPropertiesPacket.Message(
+                    player.getEntityId(),
+                    get(player).getData());
+
+            // The player is temporarily absent from the destination world's tracker during some teleports
+            ModNetwork.net.sendTo(message, player);
+            player.getServerForPlayer().getEntityTracker().func_151247_a(player, ModNetwork.net.getPacketFrom(message));
         } catch (Exception ex) {
             ex.printStackTrace();
         }

--- a/src/main/java/com/darkona/adventurebackpack/proxy/ServerProxy.java
+++ b/src/main/java/com/darkona/adventurebackpack/proxy/ServerProxy.java
@@ -1,19 +1,8 @@
 package com.darkona.adventurebackpack.proxy;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
-import com.darkona.adventurebackpack.playerProperties.BackpackProperty;
-import com.darkona.adventurebackpack.util.LogHelper;
-
 public class ServerProxy implements IProxy {
-
-    private static final Map<UUID, NBTTagCompound> extendedEntityData = new HashMap<>();
 
     @Override
     public void init() {}
@@ -23,24 +12,4 @@ public class ServerProxy implements IProxy {
 
     @Override
     public void synchronizePlayer(int id, NBTTagCompound compound) {}
-
-    public static void storePlayerProps(EntityPlayer player) {
-        try {
-            NBTTagCompound data = BackpackProperty.get(player).getData();
-            if (data.hasKey("wearable")) {
-                LogHelper.info(
-                        "Storing wearable: "
-                                + ItemStack.loadItemStackFromNBT(data.getCompoundTag("wearable")).getDisplayName());
-            }
-            extendedEntityData.put(player.getUniqueID(), data);
-            LogHelper.info("Stored player properties for dead player");
-        } catch (Exception ex) {
-            LogHelper.error("Something went wrong while saving player properties: " + ex.getMessage());
-            ex.printStackTrace();
-        }
-    }
-
-    public static NBTTagCompound extractPlayerProps(UUID playerID) {
-        return extendedEntityData.remove(playerID);
-    }
 }


### PR DESCRIPTION
## Summary
Fixes backpack disapearing when using keepinventory in singleplayer and leaving the world before respawning.

Fixes backpack desyncing from server when traveling between dimensions (player doesn't see their backpack anymore until going back to the original dimension).

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/5035




## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
