### PR TITLE
Fix coal jetpack elevation thrust cutoff handling

### DIFF
--- a/src/main/java/com/darkona/adventurebackpack/item/ItemCoalJetpack.java
+++ b/src/main/java/com/darkona/adventurebackpack/item/ItemCoalJetpack.java
@@ -158,10 +158,12 @@ public class ItemCoalJetpack extends ItemAdventure {
     }
 
     private static void elevate(EntityPlayer player) {
-        if (player.posY < 135) if (player.motionY <= 0.32) player.motionY += 0.1;
-        else player.motionY = Math.max(player.motionY, 0.32);
-        else if (player.posY < 185) player.motionY = 0.32 - (player.posY - 135) / 160;
-        else if (player.posY >= 185) player.motionY += 0;
+        double thrustCutoffSpeed;
+        if (player.posY < 135) thrustCutoffSpeed = 0.32;
+        else if (player.posY < 185) thrustCutoffSpeed = 0.32 - (player.posY - 135) / 160;
+        else return;
+
+        if (player.motionY <= thrustCutoffSpeed) player.motionY += 0.1;
     }
 
     private void runBoiler(InventoryCoalJetpack inv, World world, EntityPlayer player) {


### PR DESCRIPTION
## Summary
Fix coal jetpack elevation thrust cutoff handling.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20238

### Behaviour Change
At Y=150, a player falling with `motionY = -2.0` activates the jetpack.

Previously, their velocity was immediately set to about `0.23`, stopping the fall instantly.

Now, thrust adds `0.1`, changing their velocity to `-1.9`. Continued thrust slows the fall progressively while preserving momentum.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
